### PR TITLE
LR_Justify v2

### DIFF
--- a/LRJustify/LR_Justify.pas
+++ b/LRJustify/LR_Justify.pas
@@ -1,10 +1,20 @@
-//LR_Justify Script: by John M. Go-Soco v1.0
+//LR_Justify Script: by John M. Go-Soco
 //  Note:  This script is intended for use in the Schematic editor. It is best used when assigned to a shortcut key. 
 //  Assign it first to a button/icon:
 //   Process: ScriptingSystem:RunScriptFile
 //   Parameters: Filename = <FULL FILE PATH HERE> | Procname = LR_Justify
 //  then assign it a shortcut key.
 //  USAGE: Select some text, activate the script, and it will swap it from left justification to right justification.
+
+Function Modify_Begin(TObject);
+begin
+    SchServer.RobotManager.SendMessage(TObject.I_ObjectAddress, c_BroadCast, SCHM_BeginModify, c_NoEventData);
+end;
+
+Function Modify_End(TObject);
+begin
+    SchServer.RobotManager.SendMessage(TObject.I_ObjectAddress, c_BroadCast, SCHM_EndModify, c_NoEventData);
+end;
 
 procedure LR_Justify;
   Var
@@ -29,15 +39,20 @@ procedure LR_Justify;
             begin
                  if txt.selection = true then
                     begin
+                        Modify_Begin(txt);  					
                       case txt.justification of
-                        akLeft  : txt.justification := akRight;
-                        akRight : txt.justification := akLeft;
+						eJustify_BottomLeft     : txt.Justification := eJustify_BottomRight;
+						eJustify_BottomRight    : txt.Justification := eJustify_BottomLeft;
+						eJustify_CenterLeft     : txt.Justification := eJustify_CenterRight;
+						eJustify_CenterRight    : txt.Justification := eJustify_CenterLeft;
+						eJustify_TopLeft        : txt.Justification := eJustify_TopRight;
+						eJustify_TopRight       : txt.Justification := eJustify_TopLeft;
                       end;
-                      //txt.Autoposition := False;
+						//txt.Autoposition := False;
+						Modify_End(txt);					  
                     end;
               txt := iterator.NextSchObject;
             end;
-
       sk.SchIterator_Destroy(iterator);
       SchServer.ProcessControl.PostProcess(sk, '');
       ResetParameters;


### PR DESCRIPTION
Replaced usage of akLeft, akRight, etc. in favour of proper enumerated
TTextJustification type, which are eJustify_BottomLeft, etc.
This means that if "vertical alignment" is anything other than "bottom",
this scrip will still work.

Also added undo functionality.