### PR TITLE
Fix Fillet.pas to correct missing function

### DIFF
--- a/Fillet/Fillet.pas
+++ b/Fillet/Fillet.pas
@@ -470,3 +470,29 @@ begin
     else if (RadioUnitsRatio.Checked = true) and (StrToFloat(tRadius.Text) <= 0) then tRadius.Text := '0.01';
 end;
 
+function IsStringANum(Text : String) : Boolean;
+var
+   i : Integer;
+   dotCount : Integer;
+begin
+   Result := True;
+
+   if Text = '' then Result := False;
+
+   // Test weather we have number, dot or comma
+   for i := 1 to Length(Text) do
+      if not(((ord(Text[i]) > 47) and (ord(Text[i]) < 58)) or (ord(Text[i]) = 44) or (ord(Text[i]) = 46)) then
+         Result := False;
+
+   // Test if we have more than one dot or comma
+   dotCount := 0;
+   for i := 1 to Length(Text) do
+      if ((ord(Text[i]) = 44) or (ord(Text[i]) = 46)) then
+      begin
+         Inc(dotCount);
+         if (i = 1) or (i = Length(Text)) then Result := False;
+      end;
+
+   if dotCount > 1 then Result := False;
+end;
+


### PR DESCRIPTION
Fillet.pas was referencing the function IsStringANum, which is found in several of the scripts in this repo. If the user has none of those other scripts installed, it will fail to find the function. This fix adds the function to the script to make it standalone.