### PR TITLE
Bug fix - Allow under default text should be ignored.

### DIFF
--- a/Scripts - PCB/AutoPlaceSilkscreen/AutoPlaceSilkscreen.dfm
+++ b/Scripts - PCB/AutoPlaceSilkscreen/AutoPlaceSilkscreen.dfm
@@ -85,7 +85,6 @@ object Form_PlaceSilk: TForm_PlaceSilk
     Width = 193
     Height = 21
     TabOrder = 5
-    Text = 'cbCmpOutlineLayer'
     OnChange = cbCmpOutlineLayerChange
   end
   object chkAvoidVias: TCheckBox

--- a/Scripts - PCB/AutoPlaceSilkscreen/AutoPlaceSilkscreen.pas
+++ b/Scripts - PCB/AutoPlaceSilkscreen/AutoPlaceSilkscreen.pas
@@ -213,7 +213,7 @@ var
     refdes : TPCB_String;
     i : Integer;
 begin
-    if AllowUnderList <> nil then
+    if (AllowUnderList <> nil) and (AllowUnderList.Count > 0) then
     begin
         For i := 0 to AllowUnderList.Count - 1 do
         begin
@@ -279,7 +279,7 @@ begin
             Obj := Obj.Component;
 
             // Allow under are user defined reference designators that can be ignored
-            if (Allow_Under(Obj, AllowUnderList)) or (Obj.Name.Layer <> Slk.Layer) then
+            if (Obj = nil) or (Allow_Under(Obj, AllowUnderList)) or (Obj.Name.Layer <> Slk.Layer) then
             begin
                  Obj := Iterator.NextPCBObject;
                  Continue;
@@ -772,8 +772,11 @@ begin
      AvoidVias := chkAvoidVias.Checked;
 
      AllowUnderList := TStringList.Create;
-     StrNoSpace := RemoveNewLines(MEM_AllowUnder.Text);
-     Split(',', StrNoSpace, AllowUnderList);
+     if MEM_AllowUnder.Text <> TEXTBOXINIT then
+     begin
+         StrNoSpace := RemoveNewLines(MEM_AllowUnder.Text);
+         Split(',', StrNoSpace, AllowUnderList);
+     end;
 
      Main(Place_Selected, Place_OverComp, AllowUnderList);
      AllowUnderList.Free;
@@ -812,7 +815,7 @@ begin
         MechLayerIDList.Add(IntToStr(LayerObj.V6_LayerID));
 
         // Set default layer
-        If LayerObj.Name = DEFAULT_CMP_OUTLINE_LAYER Then
+        If (LayerObj.Name = DEFAULT_CMP_OUTLINE_LAYER) or (ContainsText(LayerObj.Name, 'Component Outline')) Then
         Begin
             cbCmpOutlineLayer.SetItemIndex(idx);
             CmpOutlineLayerID := LayerObj.V6_LayerID;


### PR DESCRIPTION
I had forgotten to ignore the "Allow Under" text in it's textbox which was causing errors when not using this feature. Also, I now search for "Component Outline" in layer set to update the default combobox text.