### PR TITLE
Update fillet script to add user-configurable preset radius values

### DIFF
--- a/Scripts - PCB/Fillet/Fillet.dfm
+++ b/Scripts - PCB/Fillet/Fillet.dfm
@@ -4,7 +4,7 @@ object Form1: TForm1
   BorderIcons = [biSystemMenu]
   BorderStyle = bsDialog
   Caption = 'Fillet'
-  ClientHeight = 100
+  ClientHeight = 371
   ClientWidth = 180
   Color = clBtnFace
   Font.Charset = DEFAULT_CHARSET
@@ -14,9 +14,7 @@ object Form1: TForm1
   Font.Style = []
   OldCreateOrder = False
   Position = poOwnerFormCenter
-  DesignSize = (
-    180
-    100)
+  OnShow = Form1Show
   PixelsPerInch = 96
   TextHeight = 13
   object Label1: TLabel
@@ -32,8 +30,8 @@ object Form1: TForm1
     Width = 64
     Height = 25
     Caption = 'O&K'
-    Default = True
-    TabOrder = 3
+    TabOrder = 11
+    TabStop = False
     OnClick = ButtonOKClick
   end
   object ButtonCancel: TButton
@@ -43,7 +41,8 @@ object Form1: TForm1
     Height = 25
     Cancel = True
     Caption = '&Cancel'
-    TabOrder = 2
+    TabOrder = 10
+    TabStop = False
     OnClick = ButtonCancelClick
   end
   object tRadius: TEdit
@@ -51,13 +50,15 @@ object Form1: TForm1
     Top = 14
     Width = 48
     Height = 21
+    Align = alCustom
     Alignment = taCenter
-    Anchors = []
+    Anchors = [akTop, akRight]
     OEMConvert = True
     TabOrder = 0
     Text = '32.25'
     TextHint = 'Enter value for fixed radius'
     OnChange = tRadiusChange
+    OnKeyPress = tRadiusKeyPress
   end
   object RadioPanel: TPanel
     Left = 38
@@ -68,7 +69,7 @@ object Form1: TForm1
     Ctl3D = True
     ParentBackground = False
     ParentCtl3D = False
-    TabOrder = 1
+    TabOrder = 9
     object RadioUnitsMils: TRadioButton
       Left = 0
       Top = 0
@@ -76,8 +77,7 @@ object Form1: TForm1
       Height = 16
       Caption = 'mils'
       Checked = True
-      TabOrder = 0
-      TabStop = True
+      TabOrder = 1
     end
     object RadioUnitsMM: TRadioButton
       Left = 40
@@ -85,8 +85,7 @@ object Form1: TForm1
       Width = 40
       Height = 16
       Caption = 'mm'
-      TabOrder = 1
-      TabStop = True
+      TabOrder = 0
     end
     object RadioUnitsRatio: TRadioButton
       Left = 80
@@ -95,8 +94,207 @@ object Form1: TForm1
       Height = 16
       Caption = '%'
       TabOrder = 2
-      TabStop = True
       OnClick = RadioUnitsRatioClick
     end
+  end
+  object Button1: TButton
+    Left = 96
+    Top = 105
+    Width = 64
+    Height = 25
+    Caption = 'Preset &1'
+    TabOrder = 12
+    TabStop = False
+    OnClick = Button1Click
+  end
+  object tPreset1: TEdit
+    Left = 24
+    Top = 107
+    Width = 64
+    Height = 21
+    Align = alCustom
+    Alignment = taCenter
+    Anchors = [akTop, akRight]
+    OEMConvert = True
+    TabOrder = 1
+    Text = '25.2'
+    TextHint = 'Enter value for fixed radius'
+    OnChange = tRadiusChange
+    OnKeyPress = tPreset1KeyPress
+  end
+  object Button2: TButton
+    Left = 96
+    Top = 137
+    Width = 64
+    Height = 25
+    Caption = 'Preset &2'
+    TabOrder = 13
+    TabStop = False
+    OnClick = Button2Click
+  end
+  object tPreset2: TEdit
+    Left = 24
+    Top = 139
+    Width = 64
+    Height = 21
+    Align = alCustom
+    Alignment = taCenter
+    Anchors = [akTop, akRight]
+    OEMConvert = True
+    TabOrder = 2
+    Text = '39.1'
+    TextHint = 'Enter value for fixed radius'
+    OnChange = tRadiusChange
+    OnKeyPress = tPreset2KeyPress
+  end
+  object Button3: TButton
+    Left = 96
+    Top = 169
+    Width = 64
+    Height = 25
+    Caption = 'Preset &3'
+    TabOrder = 14
+    TabStop = False
+    OnClick = Button3Click
+  end
+  object tPreset3: TEdit
+    Left = 24
+    Top = 171
+    Width = 64
+    Height = 21
+    Align = alCustom
+    Alignment = taCenter
+    Anchors = [akTop, akRight]
+    OEMConvert = True
+    TabOrder = 3
+    Text = '32.4'
+    TextHint = 'Enter value for fixed radius'
+    OnChange = tRadiusChange
+    OnKeyPress = tPreset3KeyPress
+  end
+  object Button4: TButton
+    Left = 96
+    Top = 201
+    Width = 64
+    Height = 25
+    Caption = 'Preset &4'
+    TabOrder = 15
+    TabStop = False
+    OnClick = Button4Click
+  end
+  object tPreset4: TEdit
+    Left = 24
+    Top = 203
+    Width = 64
+    Height = 21
+    Align = alCustom
+    Alignment = taCenter
+    Anchors = [akTop, akRight]
+    OEMConvert = True
+    TabOrder = 4
+    Text = '46.3'
+    TextHint = 'Enter value for fixed radius'
+    OnChange = tRadiusChange
+    OnKeyPress = tPreset4KeyPress
+  end
+  object Button5: TButton
+    Left = 96
+    Top = 233
+    Width = 64
+    Height = 25
+    Caption = 'Preset &5'
+    TabOrder = 16
+    TabStop = False
+    OnClick = Button5Click
+  end
+  object tPreset5: TEdit
+    Left = 24
+    Top = 235
+    Width = 64
+    Height = 21
+    Align = alCustom
+    Alignment = taCenter
+    Anchors = [akTop, akRight]
+    OEMConvert = True
+    TabOrder = 5
+    Text = '41.05'
+    TextHint = 'Enter value for fixed radius'
+    OnChange = tRadiusChange
+    OnKeyPress = tPreset5KeyPress
+  end
+  object Button6: TButton
+    Left = 96
+    Top = 265
+    Width = 64
+    Height = 25
+    Caption = 'Preset &6'
+    TabOrder = 17
+    TabStop = False
+    OnClick = Button6Click
+  end
+  object tPreset6: TEdit
+    Left = 24
+    Top = 267
+    Width = 64
+    Height = 21
+    Align = alCustom
+    Alignment = taCenter
+    Anchors = [akTop, akRight]
+    OEMConvert = True
+    TabOrder = 6
+    Text = '10'
+    TextHint = 'Enter value for fixed radius'
+    OnChange = tRadiusChange
+    OnKeyPress = tPreset6KeyPress
+  end
+  object Button7: TButton
+    Left = 96
+    Top = 297
+    Width = 64
+    Height = 25
+    Caption = 'Preset &7'
+    TabOrder = 18
+    TabStop = False
+    OnClick = Button7Click
+  end
+  object tPreset7: TEdit
+    Left = 24
+    Top = 299
+    Width = 64
+    Height = 21
+    Align = alCustom
+    Alignment = taCenter
+    Anchors = [akTop, akRight]
+    OEMConvert = True
+    TabOrder = 7
+    Text = '20'
+    TextHint = 'Enter value for fixed radius'
+    OnChange = tRadiusChange
+    OnKeyPress = tPreset7KeyPress
+  end
+  object Button8: TButton
+    Left = 96
+    Top = 329
+    Width = 64
+    Height = 25
+    Caption = 'Preset &8'
+    TabOrder = 19
+    TabStop = False
+    OnClick = Button8Click
+  end
+  object tPreset8: TEdit
+    Left = 24
+    Top = 331
+    Width = 64
+    Height = 21
+    Align = alCustom
+    Alignment = taCenter
+    Anchors = [akTop, akRight]
+    OEMConvert = True
+    TabOrder = 8
+    Text = '30'
+    TextHint = 'Enter value for fixed radius'
+    OnChange = tRadiusChange
+    OnKeyPress = tPreset8KeyPress
   end
 end

--- a/Scripts - PCB/Fillet/Fillet.pas
+++ b/Scripts - PCB/Fillet/Fillet.pas
@@ -6,9 +6,12 @@
 { Created by:    Petar Perisin                                                 }
 { Edited by:    Ryan Rutledge                                                  }
 {           Edited 2018-09-15 to support any-angle tracks and fixed radius     }
+{           Edited 2022-08-01 to add configurable presets                      }
 {..............................................................................}
 
 {..............................................................................}
+uses
+    IniFiles;
 var
     Board         : IPCB_Board;
     MinDistance   : Double;
@@ -23,8 +26,9 @@ var
     ....
     I_ObjectAdressN;radiusN
     *)
-    RadiusList         :TStringList;
-
+    RadiusList  : TStringList;
+    PresetFilePath : String;
+    PresetList  : TStringList;
 
 
 
@@ -54,37 +58,38 @@ begin
    if dotCount > 1 then Result := False;
 end;
 
-procedure TForm1.ButtonOKClick(Sender: TObject);
+procedure DoFillets;
 var
-    FirstTrack         :IPCB_Primitive;
-    SecondTrack        :IPCB_Primitive;
-    XCommon            :Integer;
-    YCommon            :Integer;
-    angle1             :Double;
-    angle2             :Double;
-    Radius             :Integer;
-    k1                 :Double;
-    k2                 :Double;
-    FirstCommon        :Integer;
-    SecondCommon       :Integer;
-    Xc                 :Integer;
-    Yc                 :Integer;
-    i, j               :integer;
-    flag               :integer;
-    X1, X2, Y1, Y2     :Integer;
-    StartAngle         :Double;
-    StopAngle          :Double;
-    ArcAngle           :Double;
-    HalfAngle          :Double;
-    Arc                :IPCB_Arc;
-    Line               :String;
-    TempString         :String;
-    ObjAdr             :Int64;
-    Leng               :Integer;
-    ShortLength        :Integer;
-    NumCommon          :Integer;
-    Ratio              :Double;
-    a, b               :Integer;
+    FirstTrack          :IPCB_Primitive;
+    SecondTrack         :IPCB_Primitive;
+    XCommon             :Integer;
+    YCommon             :Integer;
+    angle1              :Double;
+    angle2              :Double;
+    Radius              :Integer;
+    k1                  :Double;
+    k2                  :Double;
+    FirstCommon         :Integer;
+    SecondCommon        :Integer;
+    Xc                  :Integer;
+    Yc                  :Integer;
+    i, j                :integer;
+    flag                :integer;
+    X1, X2, Y1, Y2      :Integer;
+    StartAngle          :Double;
+    StopAngle           :Double;
+    ArcAngle            :Double;
+    HalfAngle           :Double;
+    Arc                 :IPCB_Arc;
+    Line                :String;
+    TempString          :String;
+    ObjAdr              :Int64;
+    Leng                :Integer;
+    ShortLength         :Integer;
+    NumCommon           :Integer;
+    Ratio               :Double;
+    a, b                :Integer;
+    TempPresetList      :TStringList;
 
 begin
     // Start undo
@@ -215,8 +220,8 @@ begin
                         j    := LastDelimiter(';', Line);
 
                         ObjAdr := StrToInt64(Copy(Line, 1, j - 1));
-                        if Ratio > 0 then    
-                        begin 
+                        if Ratio > 0 then
+                        begin
                             Leng := Int(StrToInt64(Copy(Line, j + 1, length(Line))) * Ratio / 100)
                         end
                         else Leng                 := Radius;
@@ -384,6 +389,30 @@ begin
 
     RadiusList.Clear;
     
+    // build list of currect preset values
+    TempPresetList := TStringList.Create;
+    TempPresetList.Add(tPreset1.Text);
+    TempPresetList.Add(tPreset2.Text);
+    TempPresetList.Add(tPreset3.Text);
+    TempPresetList.Add(tPreset4.Text);
+    TempPresetList.Add(tPreset5.Text);
+    TempPresetList.Add(tPreset6.Text);
+    TempPresetList.Add(tPreset7.Text);
+    TempPresetList.Add(tPreset8.Text);
+   
+    If TempPresetList.Equals(PresetList) then
+    Begin
+        //presets match saved list so do nothing
+    End
+    Else Begin
+        // save new list to MyPresetList.txt
+        TempPresetList.SaveToFile(PresetFilePath);
+    End;
+    
+    // cleanup
+    PresetList.Free;
+    TempPresetList.Free;
+    
     // Display a message if no fillets have been added by script, presumably because there is an issue with track joints.
     // If even one fillet is added, don't show message. The intent is to be informative if the user runs the script and it does nothing.
     if NumCommon = 0 then ShowMessage('Selected tracks have no common point (track ends must meet EXACTLY)');
@@ -415,14 +444,15 @@ begin
 
     flag       := 0;
     RadiusList := TStringList.Create;
-
+    PresetFilePath := ClientAPI_SpecialFolder_AltiumApplicationData + '\MyFilletPresets.txt';
+    
     // Deselect any non-track objects
     i := 0;
     While i < Board.SelectecObjectCount do
     begin
         Track := Board.SelectecObject[i];
         if Track.ObjectId <> eTrackObject then Track.SetState_Selected(false)
-        else i := i + 1;	// only iterate if object wasn't deselected
+        else i := i + 1;    // only iterate if object wasn't deselected
     end;
 
     for i := 0 to Board.SelectecObjectCount - 1 do
@@ -487,11 +517,200 @@ begin
         tRadius.Text := '0.01';
         ShowInfo('% input limited to 0.01%');
     end;
+
 end;
 
 procedure TForm1.RadioUnitsRatioClick(Sender: TObject);
 begin
     if (RadioUnitsRatio.Checked = true) and (StrToFloat(tRadius.Text) >= 100) then tRadius.Text := '99.99'
     else if (RadioUnitsRatio.Checked = true) and (StrToFloat(tRadius.Text) <= 0) then tRadius.Text := '0.01';
+end;
+
+
+procedure TForm1.Form1Show(Sender: TObject);
+var
+    I : Integer;
+begin
+    // read from MyFilletPresets.txt
+    PresetList := TStringList.Create;
+    If FileExists(PresetFilePath) then
+    Begin
+        PresetList.LoadFromFile(PresetFilePath);
+        
+        // if PresetList count is short, start padding with default value
+        If PresetList.Count < 8 then
+        Begin
+            While PresetList.Count < 8 do
+            Begin
+                PresetList.Add('10');
+            End;
+            PresetList.SaveToFile(PresetFilePath);
+        End;
+        
+        //set text boxes to match preset list
+        tPreset1.Text := PresetList[0];
+        tPreset2.Text := PresetList[1];
+        tPreset3.Text := PresetList[2];
+        tPreset4.Text := PresetList[3];
+        tPreset5.Text := PresetList[4];
+        tPreset6.Text := PresetList[5];
+        tPreset7.Text := PresetList[6];
+        tPreset8.Text := PresetList[7];
+    End
+    Else Begin
+        //ShowMessage(PresetFilePath + ' does not exist.');
+        PresetList.Clear;
+        PresetList.Add(tPreset1.Text);
+        PresetList.Add(tPreset2.Text);
+        PresetList.Add(tPreset3.Text);
+        PresetList.Add(tPreset4.Text);
+        PresetList.Add(tPreset5.Text);
+        PresetList.Add(tPreset6.Text);
+        PresetList.Add(tPreset7.Text);
+        PresetList.Add(tPreset8.Text);
+        PresetList.SaveToFile(PresetFilePath);
+    end;
+end;
+
+procedure TForm1.ButtonOKClick(Sender: TObject);
+begin
+    DoFillets;
+end;
+
+procedure TForm1.tRadiusKeyPress(Sender: TObject; var Key: Char);
+begin
+    if Key = #13 then
+    begin
+        Key := #0; //don't beep
+        DoFillets;
+    end;
+end;
+
+procedure TForm1.Button1Click(Sender: TObject);
+begin
+    tRadius.Text := tPreset1.Text;
+    DoFillets;
+end;
+
+procedure TForm1.tPreset1KeyPress(Sender: TObject; var Key: Char);
+begin
+    if Key = #13 then
+    begin
+        Key := #0; //don't beep
+        tRadius.Text := tPreset1.Text;
+        DoFillets;
+    end;
+end;
+
+procedure TForm1.Button2Click(Sender: TObject);
+begin
+    tRadius.Text := tPreset2.Text;
+    DoFillets;
+end;
+
+procedure TForm1.tPreset2KeyPress(Sender: TObject; var Key: Char);
+begin
+    if Key = #13 then
+    begin
+        Key := #0; //don't beep
+        tRadius.Text := tPreset2.Text;
+        DoFillets;
+    end;
+end;
+
+procedure TForm1.Button3Click(Sender: TObject);
+begin
+    tRadius.Text := tPreset3.Text;
+    DoFillets;
+end;
+
+procedure TForm1.tPreset3KeyPress(Sender: TObject; var Key: Char);
+begin
+    if Key = #13 then
+    begin
+        Key := #0; //don't beep
+        tRadius.Text := tPreset3.Text;
+        DoFillets;
+    end;
+end;
+
+procedure TForm1.Button4Click(Sender: TObject);
+begin
+    tRadius.Text := tPreset4.Text;
+    DoFillets;
+end;
+
+procedure TForm1.tPreset4KeyPress(Sender: TObject; var Key: Char);
+begin
+    if Key = #13 then
+    begin
+        Key := #0; //don't beep
+        tRadius.Text := tPreset4.Text;
+        DoFillets;
+    end;
+end;
+
+procedure TForm1.Button5Click(Sender: TObject);
+begin
+    tRadius.Text := tPreset5.Text;
+    DoFillets;
+end;
+
+procedure TForm1.tPreset5KeyPress(Sender: TObject; var Key: Char);
+begin
+    if Key = #13 then
+    begin
+        Key := #0; //don't beep
+        tRadius.Text := tPreset5.Text;
+        DoFillets;
+    end;
+end;
+
+procedure TForm1.Button6Click(Sender: TObject);
+begin
+    tRadius.Text := tPreset6.Text;
+    DoFillets;
+end;
+
+procedure TForm1.tPreset6KeyPress(Sender: TObject; var Key: Char);
+begin
+    if Key = #13 then
+    begin
+        Key := #0; //don't beep
+        tRadius.Text := tPreset6.Text;
+        DoFillets;
+    end;
+end;
+
+procedure TForm1.Button7Click(Sender: TObject);
+begin
+    tRadius.Text := tPreset7.Text;
+    DoFillets;
+end;
+
+procedure TForm1.tPreset7KeyPress(Sender: TObject; var Key: Char);
+begin
+    if Key = #13 then
+    begin
+        Key := #0; //don't beep
+        tRadius.Text := tPreset7.Text;
+        DoFillets;
+    end;
+end;
+
+procedure TForm1.Button8Click(Sender: TObject);
+begin
+    tRadius.Text := tPreset8.Text;
+    DoFillets;
+end;
+
+procedure TForm1.tPreset8KeyPress(Sender: TObject; var Key: Char);
+begin
+    if Key = #13 then
+    begin
+        Key := #0; //don't beep
+        tRadius.Text := tPreset8.Text;
+        DoFillets;
+    end;
 end;
 

--- a/Scripts - PCB/Fillet/README.md
+++ b/Scripts - PCB/Fillet/README.md
@@ -13,13 +13,17 @@ More Editing by: Ryan Rutledge - Edited 2022-08-01 to add 8 configurable preset 
 ## Usage guide
 _Eligible objects_: two or more tracks with _exactly_ joined vertices
 _Ineligible objects_: any non-track objects will be deselected when script is launched
-_Invoke script_ and choose relevant operation from GUI.
+_Invoke script_ and choose relevant operation from GUI. Pressing <Enter> in any value field will execute the fillet operation.
 ### Fixed Radius
 _"mils" or "mm"_ will fillet selected tracks with an arc of the specified radius. Can exceed limit and reverse direction of track(s).
 ### Percentage
 _"%"_ will create a radius that will shorten the shorter of two joined tracks by the indicated percentage. May have unintended behavior when multiple tracks in series are selected.
 ### Changing Units
 Default setting is fixed radius in mils. Value presets are unitless.
+### Using Presets
+Press the preset button (or Alt+Number) to execute the fillet operation with that value. Pressing <Enter> while editing a preset will immediately execute that preset and save it.
+### Saving Presets
+Preset values are saved _every_ time you execute the fillet command, if you change a preset value. Does _not_ save if you cancel the dialog.
 
 
 ## How to install and use

--- a/Scripts - PCB/Fillet/README.md
+++ b/Scripts - PCB/Fillet/README.md
@@ -1,9 +1,29 @@
-# Fillet
-This Script creates fillet on selected tracks
+# Fillet Script
 
-Radius value = (shorter of two lines) * percentage OR fixed value
+## What is it
+This Script creates fillet(s) on selected tracks either as a percentage of the shortest connected track or with fixed radius.
 
 
 ## Credits
 Created by: Petar Perisin\
-Edited by: Ryan Rutledge - Edited 2018-09-15 to support any-angle tracks and fixed radius
+Edited by: Ryan Rutledge - Edited 2018-09-15 to support any-angle tracks and fixed radius\
+More Editing by: Ryan Rutledge - Edited 2022-08-01 to add 8 configurable preset radius values
+
+
+## Usage guide
+_Eligible objects_: two or more tracks with _exactly_ joined vertices
+_Ineligible objects_: any non-track objects will be deselected when script is launched
+_Invoke script_ and choose relevant operation from GUI.
+### Fixed Radius
+_"mils" or "mm"_ will fillet selected tracks with an arc of the specified radius. Can exceed limit and reverse direction of track(s).
+### Percentage
+_"%"_ will create a radius that will shorten the shorter of two joined tracks by the indicated percentage. May have unintended behavior when multiple tracks in series are selected.
+### Changing Units
+Default setting is fixed radius in mils. Value presets are unitless.
+
+
+## How to install and use
+_Step 1_: [DOWNLOAD the script](https://minhaskamal.github.io/DownGit/#/home?url=https://github.com/Altium-Designer-addons/scripts-libraries/tree/master/Scripts%20-%20PCB/Fillet)
+
+_Step 2_: integrate the script into Altium Designer and execute it.\
+If you are a newcomer to Altium scripts, [please read the "how to" wiki page](https://github.com/Altium-Designer-addons/scripts-libraries/wiki/HowTo_execute_scripts).


### PR DESCRIPTION
Enhanced fillet script to allow user to set up and easily use 8 different preset radius values. I found myself frequently using a few specific values so I added this to cut down on repetitive typing and remembering exact values.