### PR TITLE
Fix bug in distribute mode recall...

### DIFF
--- a/Scripts - PCB/Distribute/Distribute.pas
+++ b/Scripts - PCB/Distribute/Distribute.pas
@@ -1107,8 +1107,8 @@ begin
     begin
         RadioButtonClearance.Enabled    := False;
         RadioButtonCenters.Enabled      := False;
-        if not RadioButtonCentersVal.Checked then RadioButtonClearanceVal.Checked;
         EnableByValControls(True);
+        if not RadioButtonCentersVal.Checked then RadioButtonClearanceVal.Checked := True;
     end
     else if (RadioButtonClearanceVal.Checked or RadioButtonCentersVal.Checked) then
     begin


### PR DESCRIPTION
Where if the last mode was not a by-value distribute mode but only two tracks were selected, the previous mode would be selected while greyed out, making the script do nothing unless you manually selected a valid mode