### PR TITLE
Distribute v1.43 adds debugging log and fixes...

### DIFF
--- a/Scripts - PCB/Distribute/README.md
+++ b/Scripts - PCB/Distribute/README.md
@@ -56,3 +56,5 @@ Sometimes, particularly when distributing tracks that are not routed at 90° or 
 2022-11-16 by Ryan Rutledge : v1.41 - Added ability to trim dangling track ends perpendicular to _First Track_
 
 2022-11-17 by Ryan Rutledge : v1.42 - added version to form
+
+2022-11-17 by Ryan Rutledge : v1.43 - added debugging tools; fixed TargetSlope getting reset for each track instead of set once by _First Track_


### PR DESCRIPTION
TargetSlope value being recalculated for each track rather than only once using the first track. This makes the results much more consistent and prevents error stacking up as quickly over multiple runs of the script.