### PR TITLE
Update Distribute to v1.44

### DIFF
--- a/Scripts - PCB/Distribute/Distribute.pas
+++ b/Scripts - PCB/Distribute/Distribute.pas
@@ -325,7 +325,7 @@ begin
                 Prim1.X1 := TargetIntercept; // set to TargetIntercept
 
                 // if vertical and actual Y coords don't match output of SetupDataFromTrack, then they were coerced and swapped
-                if Prim1.Y1 = y12 then Prim1.Y1 := y02; // use swapped end instead
+                if Prim1.Y1 = y12 then Prim1.Y1 := y02 // use swapped end instead
                 else                   Prim1.Y1 := y01; // trim Y coord
 
             end

--- a/Scripts - PCB/Distribute/Distribute.pas
+++ b/Scripts - PCB/Distribute/Distribute.pas
@@ -14,7 +14,7 @@ var
 
 const
     NumPresets = 15; // no longer just for presets, also used to save previous state
-    ScriptVersion = '1.43';
+    ScriptVersion = '1.44';
 
 
 // critical function to get normalized line properties. k is slope, c is intercept
@@ -59,7 +59,7 @@ begin
         k := (Y2 - Y1) / (X2 - X1); // calculate track slope
 
         if (Abs(k) > 20) then
-        begin // if slope k > 20, consider track as vertical
+        begin // if slope k > 20, consider track as vertical (this is necessary to prevent Y-intercept number overflow)
             X1 := Prim1.X1;
             X2 := Prim1.X2;
 
@@ -323,7 +323,11 @@ begin
             if IsVert1 then
             begin // if ordinate line IsVert1 is true then perpendicular line is horizontal
                 Prim1.X1 := TargetIntercept; // set to TargetIntercept
-                Prim1.Y1 := y01; // trim Y coord
+
+                // if vertical and actual Y coords don't match output of SetupDataFromTrack, then they were coerced and swapped
+                if Prim1.Y1 = y12 then Prim1.Y1 := y02; // use swapped end instead
+                else                   Prim1.Y1 := y01; // trim Y coord
+
             end
             else // ordinate line is horizontal, perpendicular line is vertical
             begin
@@ -381,7 +385,11 @@ begin
             if IsVert1 then
             begin // if ordinate line IsVert1 is true then perpendicular line is horizontal
                 Prim1.X2 := TargetIntercept; // set to TargetIntercept
-                Prim1.Y2 := y02; // trim Y coord
+
+                // if vertical and actual Y coords don't match output of SetupDataFromTrack, then they were coerced and swapped
+                if Prim1.Y1 = y12 then Prim1.Y2 := y01 // use swapped end instead
+                else                   Prim1.Y2 := y02; // trim Y coord
+
             end
             else // ordinate line is horizontal, perpendicular line is vertical
             begin
@@ -836,7 +844,10 @@ begin
 
     minc        := c1;
     maxc        := c1;
-    coef        := cos(arctan(k1));          // y-intercept coefficient based on slope (i.e. how much intercept shifts for a perpendicular shift of the track)
+
+    if IsVert1 then coef := 1.0 // if first track has been coerced to vertical, coef needs to be 1 for later width compensation
+    else coef        := cos(arctan(k1)); // y-intercept coefficient based on slope (i.e. how much intercept shifts for a perpendicular shift of the track)
+
     cFromWidths := Prim1.Width / (2 * coef); // start cFromWidths with half of the first track's width
 
     // calculate extents of intercept values and sum of track widths in intercept units
@@ -853,7 +864,7 @@ begin
 
     cFromWidths := cFromWidths - Prim1.Width / (2 * coef); // subtract half of last track's width
 
-    midc := (minc + maxc) div 2; // midline between the outer pair of tracks
+    midc := (Round(minc + maxc)) div 2; // midline between the outer pair of tracks
 
     {
         // Test case if all is good until now

--- a/Scripts - PCB/Distribute/README.md
+++ b/Scripts - PCB/Distribute/README.md
@@ -50,6 +50,8 @@ Debug file is saved in **`%appdata%\Altium\Altium Designer {installation ID}\Dis
 ## Known Issues
 ### Rounding errors with tracks that aren't at 90/45 angles
 Sometimes, particularly when distributing tracks that are not routed at 90° or 45° angles, rounding errors can occur due to precision of double data type and Altium TCoord unit resolution. Errors up to 0.002mil have been observed.
+### Tracks that are nearly, but not quite, vertical
+Tracks with a slope greater than 20 (90° > angle > ~87.137°) will be coerced to be perfectly vertical. This is a limitation of the Double number type. In short, angles that are too steep will have Y-intercept values that are too large to handle.
 
 ## Change log
 2022-11-02 by Ryan Rutledge : v1.3 - Added support for up to 8 user presets for by-value inputs; remembers last-used by-value input
@@ -61,3 +63,5 @@ Sometimes, particularly when distributing tracks that are not routed at 90° or 
 2022-11-17 by Ryan Rutledge : v1.42 - added version to form
 
 2022-11-17 by Ryan Rutledge : v1.43 - added debugging tools; fixed TargetSlope getting reset for each track instead of set once by _First Track_
+
+2022-11-18 by Ryan Rutledge : v1.44 - fixed bug where near-vertical tracks wouldn't trim properly if ends were normalized; fixed overflow error for steep angles; fixed invalid distribution if tracks are near vertical and are coerced to vertical


### PR DESCRIPTION
fixed bug where near-vertical tracks wouldn't trim properly if ends were normalized; fixed overflow error for steep angles; fixed invalid distribution if tracks are near vertical and are coerced to vertical