### PR TITLE
Distribute v1.45

### DIFF
--- a/Scripts - PCB/Distribute/Distribute.dfm
+++ b/Scripts - PCB/Distribute/Distribute.dfm
@@ -3,7 +3,7 @@ object FormDistribute: TFormDistribute
   Top = 0
   BorderIcons = [biSystemMenu]
   Caption = 'Distribute'
-  ClientHeight = 266
+  ClientHeight = 274
   ClientWidth = 354
   Color = clBtnFace
   Font.Charset = DEFAULT_CHARSET
@@ -19,7 +19,7 @@ object FormDistribute: TFormDistribute
     Left = 8
     Top = 65
     Width = 192
-    Height = 136
+    Height = 143
   end
   object Bevel2: TBevel
     Left = 8
@@ -29,7 +29,7 @@ object FormDistribute: TFormDistribute
   end
   object LabelVersion: TLabel
     Left = 13
-    Top = 183
+    Top = 191
     Width = 54
     Height = 13
     Caption = 'version X.X'
@@ -37,8 +37,8 @@ object FormDistribute: TFormDistribute
   object RadioDirections: TRadioGroup
     Left = 112
     Top = 120
-    Width = 56
-    Height = 72
+    Width = 80
+    Height = 80
     Hint = 'Distribution direction. Choose one for more info.'
     Caption = 'Direction'
     DoubleBuffered = False
@@ -50,7 +50,7 @@ object FormDistribute: TFormDistribute
     ItemIndex = 0
     Items.Strings = (
       '&FWD'
-      '&CEN'
+      '&CEN/VIA'
       '&REV')
     ParentDoubleBuffered = False
     ParentFont = False
@@ -119,7 +119,7 @@ object FormDistribute: TFormDistribute
   end
   object ButtonOK: TButton
     Left = 16
-    Top = 233
+    Top = 241
     Width = 75
     Height = 25
     Caption = 'OK'
@@ -129,7 +129,7 @@ object FormDistribute: TFormDistribute
   end
   object ButtonCancel: TButton
     Left = 104
-    Top = 233
+    Top = 241
     Width = 75
     Height = 25
     Cancel = True
@@ -139,7 +139,7 @@ object FormDistribute: TFormDistribute
   end
   object ButtonPreset1: TButton
     Left = 280
-    Top = 9
+    Top = 17
     Width = 64
     Height = 25
     Caption = 'Preset &1'
@@ -149,7 +149,7 @@ object FormDistribute: TFormDistribute
   end
   object tPreset1: TEdit
     Left = 208
-    Top = 11
+    Top = 19
     Width = 64
     Height = 21
     Align = alCustom
@@ -163,7 +163,7 @@ object FormDistribute: TFormDistribute
   end
   object ButtonPreset2: TButton
     Left = 280
-    Top = 41
+    Top = 49
     Width = 64
     Height = 25
     Caption = 'Preset &2'
@@ -173,7 +173,7 @@ object FormDistribute: TFormDistribute
   end
   object tPreset2: TEdit
     Left = 208
-    Top = 43
+    Top = 51
     Width = 64
     Height = 21
     Align = alCustom
@@ -187,7 +187,7 @@ object FormDistribute: TFormDistribute
   end
   object ButtonPreset3: TButton
     Left = 280
-    Top = 73
+    Top = 81
     Width = 64
     Height = 25
     Caption = 'Preset &3'
@@ -197,7 +197,7 @@ object FormDistribute: TFormDistribute
   end
   object tPreset3: TEdit
     Left = 208
-    Top = 75
+    Top = 83
     Width = 64
     Height = 21
     Align = alCustom
@@ -211,7 +211,7 @@ object FormDistribute: TFormDistribute
   end
   object ButtonPreset4: TButton
     Left = 280
-    Top = 105
+    Top = 113
     Width = 64
     Height = 25
     Caption = 'Preset &4'
@@ -221,7 +221,7 @@ object FormDistribute: TFormDistribute
   end
   object tPreset4: TEdit
     Left = 208
-    Top = 107
+    Top = 115
     Width = 64
     Height = 21
     Align = alCustom
@@ -235,7 +235,7 @@ object FormDistribute: TFormDistribute
   end
   object ButtonPreset5: TButton
     Left = 280
-    Top = 137
+    Top = 145
     Width = 64
     Height = 25
     Caption = 'Preset &5'
@@ -245,7 +245,7 @@ object FormDistribute: TFormDistribute
   end
   object tPreset5: TEdit
     Left = 208
-    Top = 139
+    Top = 147
     Width = 64
     Height = 21
     Align = alCustom
@@ -259,7 +259,7 @@ object FormDistribute: TFormDistribute
   end
   object ButtonPreset6: TButton
     Left = 280
-    Top = 169
+    Top = 177
     Width = 64
     Height = 25
     Caption = 'Preset &6'
@@ -269,7 +269,7 @@ object FormDistribute: TFormDistribute
   end
   object tPreset6: TEdit
     Left = 208
-    Top = 171
+    Top = 179
     Width = 64
     Height = 21
     Align = alCustom
@@ -283,7 +283,7 @@ object FormDistribute: TFormDistribute
   end
   object ButtonPreset7: TButton
     Left = 280
-    Top = 201
+    Top = 209
     Width = 64
     Height = 25
     Caption = 'Preset &7'
@@ -293,7 +293,7 @@ object FormDistribute: TFormDistribute
   end
   object tPreset7: TEdit
     Left = 208
-    Top = 203
+    Top = 211
     Width = 64
     Height = 21
     Align = alCustom
@@ -307,7 +307,7 @@ object FormDistribute: TFormDistribute
   end
   object ButtonPreset8: TButton
     Left = 280
-    Top = 233
+    Top = 241
     Width = 64
     Height = 25
     Caption = 'Preset &8'
@@ -317,7 +317,7 @@ object FormDistribute: TFormDistribute
   end
   object tPreset8: TEdit
     Left = 208
-    Top = 235
+    Top = 243
     Width = 64
     Height = 21
     Align = alCustom
@@ -331,7 +331,7 @@ object FormDistribute: TFormDistribute
   end
   object CheckBoxTrimEnds: TCheckBox
     Left = 16
-    Top = 208
+    Top = 216
     Width = 184
     Height = 17
     Caption = '&Trim Unconnected Track Ends'

--- a/Scripts - PCB/Distribute/Distribute.pas
+++ b/Scripts - PCB/Distribute/Distribute.pas
@@ -7,14 +7,17 @@ var
     PresetFilePath    : string;
     PresetList        : TStringList;
     SortedTracks      : TStringList;
+    SortedVias        : TStringList;
     TrimPerpendicular : Boolean; // test feature that trims dangling track ends
     DebuggingEnabled  : Boolean; // debug feature will log before-and-after results of tracks modified by script
     DebugFilePath     : string;
     DebugList         : TStringList;
+    ViaDebugFilePath  : string;
+    ViaDebugList      : TStringList;
 
 const
     NumPresets = 15; // no longer just for presets, also used to save previous state
-    ScriptVersion = '1.44';
+    ScriptVersion = '1.45';
 
 
 // critical function to get normalized line properties. k is slope, c is intercept
@@ -107,6 +110,40 @@ begin
 end;
 
 
+// Checks if PrimVia and PrimTrack are on the same layer and provides via coordinates, size, and projected line parallel to provided track, and returns True if successful.
+procedure SetupDataFromVia(var PrimVia : IPCB_Via, var PrimTrack : IPCB_Track, out k : Double, out c : TCoord, out IsIntVert : Boolean, out X : TCoord, out Y : TCoord, out size : TCoord);
+var
+    ViaLayer                : TLayer;
+    TrackLayer              : TLayer;
+    IsVert1                 : Boolean;
+    x11, x12, y11, y12      : TCoord;
+    k1, k2                  : Double;
+    c1                      : TCoord;
+
+begin
+    size := 0;
+
+    // Check if PrimVia and PrimTrack exist
+    if (PrimVia = nil) or (PrimTrack = nil) then exit;
+
+    // Check if PrimVia intersects the same layer as PrimTrack
+    if PrimVia.IntersectLayer(PrimTrack.Layer) then
+    begin
+        // Set the via coordinates and size
+        X := PrimVia.X;
+        Y := PrimVia.Y;
+        size := Max(PrimVia.StackSizeOnLayer(PrimTrack.Layer), PrimVia.HoleSize); // size should be assumed to be at least HoleSize
+    end;
+
+        // Get the parameters of the track (only actually using 'k1', 'c1')
+        SetupDataFromTrack(PrimTrack, IsVert1, x11, y11, x12, y12, k1, c1);
+
+        // Get the parameters of the parallel line
+        GetParallelLine(k1, c1, IsVert1, k, c, IsIntVert, X, Y);
+
+end;
+
+
 // debugging function
 procedure AddToDebugListBefore(var Prim : IPCB_Track, TargetSlope : Double, TargetIntercept : TCoord);
 var
@@ -117,18 +154,23 @@ var
     TempDebugList   : TStringList;
 
 begin
-    TempDebugList := TStringList.Create;
-    SetupDataFromTrack(Prim, IsVert, X1, Y1, X2, Y2, k, c);
-    TempDebugList.Append(IntToStr(X1));
-    TempDebugList.Append(IntToStr(Y1));
-    TempDebugList.Append(IntToStr(X2));
-    TempDebugList.Append(IntToStr(Y2));
-    TempDebugList.Append(FloatToStr(k));
-    TempDebugList.Append(IntToStr(c));
-    TempDebugList.Append(FloatToStr(TargetSlope));
-    TempDebugList.Append(IntToStr(TargetIntercept));
-    DebugList.Append(TempDebugList.CommaText);
-    TempDebugList.Free;
+    try
+        TempDebugList := TStringList.Create;
+        SetupDataFromTrack(Prim, IsVert, X1, Y1, X2, Y2, k, c);
+        TempDebugList.Append(IntToStr(X1));
+        TempDebugList.Append(IntToStr(Y1));
+        TempDebugList.Append(IntToStr(X2));
+        TempDebugList.Append(IntToStr(Y2));
+        TempDebugList.Append(FloatToStr(k));
+        TempDebugList.Append(IntToStr(c));
+        TempDebugList.Append(FloatToStr(TargetSlope));
+        TempDebugList.Append(IntToStr(TargetIntercept));
+        DebugList.Append(TempDebugList.CommaText);
+
+    finally
+        TempDebugList.Free;
+
+    end;
 end;
 
 
@@ -142,23 +184,94 @@ var
     TempDebugList   : TStringList;
 
 begin
-    TempDebugList := TStringList.Create;
-    TempDebugList.CommaText := DebugList[DebugList.Count - 1];
-    DebugList.Delete(DebugList.Count - 1);
-    SetupDataFromTrack(Prim, IsVert, X1, Y1, X2, Y2, k, c);
-    TempDebugList.Append(IntToStr(X1));
-    TempDebugList.Append(IntToStr(Y1));
-    TempDebugList.Append(IntToStr(X2));
-    TempDebugList.Append(IntToStr(Y2));
-    TempDebugList.Append(FloatToStr(k));
-    TempDebugList.Append(IntToStr(c));
-    TempDebugList.Append(IntToStr(LastIntercept));
-    DebugList.Append(TempDebugList.CommaText);
-    TempDebugList.Free;
+    try
+        TempDebugList := TStringList.Create;
+        TempDebugList.CommaText := DebugList[DebugList.Count - 1];
+        DebugList.Delete(DebugList.Count - 1);
+        SetupDataFromTrack(Prim, IsVert, X1, Y1, X2, Y2, k, c);
+        TempDebugList.Append(IntToStr(X1));
+        TempDebugList.Append(IntToStr(Y1));
+        TempDebugList.Append(IntToStr(X2));
+        TempDebugList.Append(IntToStr(Y2));
+        TempDebugList.Append(FloatToStr(k));
+        TempDebugList.Append(IntToStr(c));
+        TempDebugList.Append(IntToStr(LastIntercept));
+        DebugList.Append(TempDebugList.CommaText);
+
+    finally
+        TempDebugList.Free;
+
+    end;
 end;
 
 
-// function to create slope and intercept for virtual line perpendicular to a point (k1,c1,IsPrim1Vert are for ordinate line; k2,c2,IsPrim2Vert are for perpendicular line; X,Y are ordinate line endpoint)
+// debugging function
+procedure AddToDebugListFirstVia(var Prim1 : IPCB_Via, var Prim2 : IPCB_Track);
+var
+    X1, Y1          : TCoord;
+    k               : Double;
+    c               : TCoord;
+    IsVert          : Boolean;
+    ViaSize         : TCoord;
+    TempDebugList   : TStringList;
+
+begin
+    try
+        TempDebugList := TStringList.Create;
+        SetupDataFromVia(Prim1, Prim2, k, c, IsVert, X1, Y1, ViaSize);
+        TempDebugList.Append(IntToStr(X1));
+        TempDebugList.Append(IntToStr(Y1));
+        TempDebugList.Append(IntToStr(ViaSize));
+        TempDebugList.Append(FloatToStr(k));
+        TempDebugList.Append(IntToStr(c));
+        ViaDebugList.Append(TempDebugList.CommaText);
+
+    finally
+        TempDebugList.Free;
+
+    end;
+end;
+
+
+// debugging function
+procedure AddToDebugListSecondVia(var Prim1 : IPCB_Via, var Prim2 : IPCB_Track, const viaminc : TCoord, const viamaxc : TCoord, const midc : TCoord);
+var
+    X1, Y1, X2, Y2  : TCoord;
+    k               : Double;
+    c               : TCoord;
+    IsVert          : Boolean;
+    ViaSize         : TCoord;
+    TempDebugList   : TStringList;
+    trackslope      : Double;
+    trackintercept  : TCoord;
+
+begin
+    try
+        TempDebugList := TStringList.Create;
+        TempDebugList.CommaText := ViaDebugList[ViaDebugList.Count - 1];
+        ViaDebugList.Delete(ViaDebugList.Count - 1);
+        SetupDataFromVia(Prim1, Prim2, k, c, IsVert, X1, Y1, ViaSize);
+        TempDebugList.Append(IntToStr(X1));
+        TempDebugList.Append(IntToStr(Y1));
+        TempDebugList.Append(IntToStr(ViaSize));
+        TempDebugList.Append(FloatToStr(k));
+        TempDebugList.Append(IntToStr(c));
+        SetupDataFromTrack(Prim2, IsVert, X1, Y1, X2, Y2, trackslope, trackintercept);
+        TempDebugList.Append(FloatToStr(trackslope));
+        TempDebugList.Append(IntToStr(trackintercept));
+        TempDebugList.Append(IntToStr(viaminc));
+        TempDebugList.Append(IntToStr(viamaxc));
+        TempDebugList.Append(IntToStr(midc));
+        ViaDebugList.Append(TempDebugList.CommaText);
+
+    finally
+        TempDebugList.Free;
+
+    end;
+end;
+
+
+// function to create slope and intercept for virtual line perpendicular to a point (k1,c1,IsPrim1Vert are for ordinate line; k2,c2,IsPrim2Vert are for perpendicular line; X,Y are a point that the perpendicular line passes through)
 function GetPerpendicularLine(k1 : Double, c1 : TCoord, IsPrim1Vert : Boolean, out k2 : Double, out c2 : TCoord, out IsPrim2Vert : Boolean, X : TCoord, Y : TCoord) : Boolean;
 begin
     Result := True;
@@ -171,7 +284,6 @@ begin
     else if k1 = 0 then
     begin // if first line is horizontal, perpendicular line is simply vertical
         IsPrim2Vert := True;
-        k2          := 999; // pretty sure this is unnecessary if IsPrim2Vert = True
         c2          := X;
     end
     else // if first line is not vertical or horizontal
@@ -180,6 +292,32 @@ begin
         IsPrim2Vert := False;
         k2          := 1.0 / (-k1);  // perpendicular slope is negative reciprocal
         c2          := Y - (k2 * X); // perpendicular line intercept
+    end;
+end;
+
+
+// function to create slope and intercept for virtual line parallel to an ordinate line and passing through a point (k1,c1,IsPrim1Vert are for ordinate line)
+function GetParallelLine(k1 : Double; c1 : TCoord; IsPrim1Vert : Boolean; out k2 : Double; out c2 : TCoord; out IsPrim2Vert : Boolean; const X : TCoord; const Y : TCoord) : Boolean;
+begin
+    Result := True;
+
+    if IsPrim1Vert then
+    begin // If the first line is vertical, the parallel line is also vertical
+        IsPrim2Vert := True;
+        c2          := X;
+    end
+    else if k1 = 0 then
+    begin // If the first line is horizontal, the parallel line is also horizontal
+        IsPrim2Vert := False;
+        k2          := 0;
+        c2          := Y;
+    end
+    else // If the first line is not vertical or horizontal
+    begin
+        Result      := False; // Return false if the parallel line is not horizontal or vertical
+        IsPrim2Vert := False;
+        k2          := k1;
+        c2          := Y - (k2 * X); // Parallel line intercept
     end;
 end;
 
@@ -612,63 +750,88 @@ var
     Prim1              : IPCB_Primitive;
     k1, k2             : Double;
     c1, c2,            : TCoord;
-    IsVert1            : Boolean;
-    IsVert2            : Boolean;
-    x11, x12, y11, y12 : TCoord; // altium zapis koordinata
+    IsVert1, IsVert2   : Boolean;
+    x11, x12, y11, y12 : TCoord;
     x21, x22, y21, y22 : TCoord;
+    ViaCount           : Integer;
 begin
     status := 0; // clear result status
 
     // Checks if current document is a PCB kind if not, exit.
     Board := PCBServer.GetCurrentPCBBoard;
     if Board = nil then exit;
-    // testiramo da li otvren trenutb aktivan PCB doc
 
-    // need to deselect anything that isn't an electrical track as these will cause errors elsewhere
-    i := 0;
-    while i < Board.SelectecObjectCount do
+    ViaCount := 0;
+
+    // Count vias without deselecting them (assume vias should be in a net
+    for i := 0 to Board.SelectecObjectCount - 1 do
     begin
         Prim1 := Board.SelectecObject[i];
-        if ((Prim1.ObjectId <> eTrackObject) or (not Prim1.InNet)) then Prim1.SetState_Selected(False)
-        else i := i + 1; // advance iterator if current object remains selected
+        if ((Prim1.ObjectId = eViaObject) and (Prim1.InNet)) then ViaCount := ViaCount + 1;
+    end;
+
+    // If there are greater or less than 2 vias, deselect all vias
+    if (ViaCount <> 2) then
+    begin
+        // need to deselect anything that isn't an electrical track as these will cause errors elsewhere
+        i := 0;
+        while i < Board.SelectecObjectCount do
+        begin
+            Prim1 := Board.SelectecObject[i];
+            if ((Prim1.ObjectId <> eTrackObject) or (not Prim1.InNet)) then Prim1.SetState_Selected(False)
+            else i := i + 1; // advance iterator if current object remains selected
+        end;
+    end
+    else
+    begin
+        // need to deselect anything that isn't an electrical track or the two vias as these will cause errors elsewhere)
+        i := 0;
+        while i < Board.SelectecObjectCount do
+        begin
+            Prim1 := Board.SelectecObject[i];
+            if (((Prim1.ObjectId <> eTrackObject) and (Prim1.ObjectId <> eViaObject)) or (not Prim1.InNet)) then Prim1.SetState_Selected(False)
+            else i := i + 1; // advance iterator if current object remains selected
+        end;
     end;
 
 
-    if Board.SelectecObjectCount < 2 then
+    // make sure there are enough objects selected to operate upon
+    if ((ViaCount = 2) and (Board.SelectecObjectCount < 3)) or ((ViaCount <> 2) and (Board.SelectecObjectCount < 2)) then
     begin
-        Showmessage('Select at least 2 tracks that belong to nets');
+        Showmessage('Select at least 2 tracks or a pair of vias and a track that belong to nets');
         status := 1;
         exit;
     end;
 
-
-    for i := 0 to Board.SelectecObjectCount - 1 do
+    // Since we're allowing vias now, we should instead iterate until reaching the first track
+    // Find the first track and store its index in 'i'
+    i := 0;
+    while (Board.SelectecObject[i].ObjectId <> eTrackObject) and (i < Board.SelectecObjectCount - 1) do
     begin
-        Prim1 := Board.SelectecObject[i];
-
-        if (Prim1.ObjectId <> eTrackObject) then
-        begin
-            Showmessage('Select only tracks');
-            status := 1;
-            exit;
-        end;
+        i := i + 1;
     end;
 
-    Prim1 := Board.SelectecObject[0];
+    // Set up the initial track data
+    Prim1 := Board.SelectecObject[i];
     SetupDataFromTrack(Prim1, IsVert1, x11, y11, x12, y12, k1, c1);
 
-    // check that all selected tracks are parallel with the first one
-    for i := 1 to Board.SelectecObjectCount - 1 do
+    // Check that all selected tracks are parallel with the first one, skipping vias
+    i := i + 1;
+    while i < Board.SelectecObjectCount do
     begin
         Prim1 := Board.SelectecObject[i];
-        SetupDataFromTrack(Prim1, IsVert2, x21, y21, x22, y22, k2, c2);
-
-        if ((IsVert1 <> IsVert2) or (Abs(k1 - k2) > 0.01)) then
+        if Prim1.ObjectId = eTrackObject then
         begin
-            Showmessage('Selected tracks have to be parallel.');
-            status := 1;
-            exit;
+            SetupDataFromTrack(Prim1, IsVert2, x21, y21, x22, y22, k2, c2);
+
+            if ((IsVert1 <> IsVert2) or (Abs(k1 - k2) > 0.01)) then
+            begin
+                Showmessage('Selected tracks have to be parallel.');
+                status := 1;
+                exit;
+            end;
         end;
+        i := i + 1;
     end;
 end;
 
@@ -698,50 +861,190 @@ end;
 // function to load preset list from file
 procedure LoadPresetListFromFile(const dummy : Integer);
 begin
-    // default file name is MyDistributePresets.txt
-    PresetFilePath := ClientAPI_SpecialFolder_AltiumApplicationData + '\MyDistributePresets.txt';
-    PresetList     := TStringList.Create;
-    if FileExists(PresetFilePath) then
-    begin
-        // ShowMessage('Loading presets from ' + PresetFilePath);
-        PresetList.LoadFromFile(PresetFilePath); // load presets from file if it exists
+    try
+        // default file name is MyDistributePresets.txt
+        PresetFilePath := ClientAPI_SpecialFolder_AltiumApplicationData + '\MyDistributePresets.txt';
+        PresetList     := TStringList.Create;
+        if FileExists(PresetFilePath) then
+        begin
+            // ShowMessage('Loading presets from ' + PresetFilePath);
+            PresetList.LoadFromFile(PresetFilePath); // load presets from file if it exists
 
-        case PresetList.Count of
-            14 : PresetList.Add(CheckBoxTrimEnds.Checked); // PresetList[14] (14-element PresetList implies v1.4)
-            NumPresets :
-                begin
-                    // do nothing
-                end
-            else  // if PresetList.Count < NumPresets then PresetList file exists but count is short, just regenerate preset file from defaults
-                begin
-                    // ShowMessage(PresetFilePath + ' exists but is not the correct length. Defaults will be used.');
-                    BuildPresetList(PresetList);
-                    PresetList.SaveToFile(PresetFilePath);
-                end;
+            case PresetList.Count of
+                14 : PresetList.Add(CheckBoxTrimEnds.Checked); // PresetList[14] (14-element PresetList implies v1.4)
+                NumPresets :
+                    begin
+                        // do nothing
+                    end
+                else  // if PresetList.Count < NumPresets then PresetList file exists but count is short, just regenerate preset file from defaults
+                    begin
+                        // ShowMessage(PresetFilePath + ' exists but is not the correct length. Defaults will be used.');
+                        BuildPresetList(PresetList);
+                        PresetList.SaveToFile(PresetFilePath);
+                    end;
+            end;
+
+            // set text boxes to match preset list (redundant if list was regenerated above)
+            tPreset1.Text                   := PresetList[1];
+            tPreset2.Text                   := PresetList[2];
+            tPreset3.Text                   := PresetList[3];
+            tPreset4.Text                   := PresetList[4];
+            tPreset5.Text                   := PresetList[5];
+            tPreset6.Text                   := PresetList[6];
+            tPreset7.Text                   := PresetList[7];
+            tPreset8.Text                   := PresetList[8];
+            RadioDirections.ItemIndex       := PresetList[9];
+            RadioButtonClearance.Checked    := PresetList[10];
+            RadioButtonCenters.Checked      := PresetList[11];
+            RadioButtonClearanceVal.Checked := PresetList[12];
+            RadioButtonCentersVal.Checked   := PresetList[13];
+            CheckBoxTrimEnds.Checked        := PresetList[14];
+            EditDistance.Text               := PresetList[0]; // Main input field needs to be set last because setting each preset updates it
+        end
+        else
+        begin // if preset file didn't exist at all, create from defaults
+            // ShowMessage(PresetFilePath + ' does not exist.');
+            BuildPresetList(PresetList);
+            PresetList.SaveToFile(PresetFilePath);
         end;
 
-        // set text boxes to match preset list (redundant if list was regenerated above)
-        tPreset1.Text                   := PresetList[1];
-        tPreset2.Text                   := PresetList[2];
-        tPreset3.Text                   := PresetList[3];
-        tPreset4.Text                   := PresetList[4];
-        tPreset5.Text                   := PresetList[5];
-        tPreset6.Text                   := PresetList[6];
-        tPreset7.Text                   := PresetList[7];
-        tPreset8.Text                   := PresetList[8];
-        RadioDirections.ItemIndex       := PresetList[9];
-        RadioButtonClearance.Checked    := PresetList[10];
-        RadioButtonCenters.Checked      := PresetList[11];
-        RadioButtonClearanceVal.Checked := PresetList[12];
-        RadioButtonCentersVal.Checked   := PresetList[13];
-        CheckBoxTrimEnds.Checked        := PresetList[14];
-        EditDistance.Text               := PresetList[0]; // Main input field needs to be set last because setting each preset updates it
-    end
-    else
-    begin // if preset file didn't exist at all, create from defaults
-        // ShowMessage(PresetFilePath + ' does not exist.');
-        BuildPresetList(PresetList);
-        PresetList.SaveToFile(PresetFilePath);
+    except
+        begin
+            PresetList.Free;
+        end;
+    end;
+end;
+
+
+procedure PadAndSort(var list : TStringList);
+var
+    i, j                        : Integer;
+    NumOfChar, MaxNumOfChar     : Integer;
+    TempString                  : string;
+
+begin
+    // pad strings with leading zeros for sort function
+    MaxNumOfChar := 0;
+    for i        := 0 to list.Count - 1 do
+    begin
+        NumOfChar                                       := Length(list[i]);
+        if (MaxNumOfChar < NumOfChar) then MaxNumOfChar := NumOfChar;
+    end;
+
+    for i := 0 to list.Count - 1 do
+    begin
+        TempString := list[i];
+
+        while (Length(TempString) < MaxNumOfChar) do Insert('0', TempString, 2);
+
+        list[i] := TempString;
+    end;
+
+    list.Sort;
+
+    // Sort list again to put negative intercepts at the front
+    // ShowMessage (list[0][1]);  // display the first character of the first element's string
+    if (list[list.Count - 1][1] = '-') then
+    begin // if last track in sorted list has negative intercept
+        i := 0;
+
+        // advance i to last positive intercept
+        while (list[i][1] = '+') do inc(i);
+
+        j := 0;
+
+        while (i < list.Count) do
+        begin // move negative intercepts to beginning of list (before positive intercepts)
+            list.Move(list.Count - 1, j);
+            inc(j);
+            inc(i);
+        end;
+    end;
+end;
+
+
+procedure CompileSortedTracks(const dummy : Integer);
+var
+    i                           : Integer;
+    TempString                  : string;
+    Prim1                       : IPCB_Primitive;
+    k2                          : Double;
+    c2                          : TCoord;
+    IsVert2                     : Boolean;
+    x21, x22, y21, y22          : TCoord;
+
+begin
+    // we have to sort the tracks in order because they are random
+    SortedTracks := TStringList.Create;
+
+    // populate the initial list with only tracks
+    i := 0;
+    while i < Board.SelectecObjectCount do
+    begin
+        Prim1 := Board.SelectecObject[i];
+        if Prim1.ObjectId = eTrackObject then
+        begin
+            SetupDataFromTrack(Prim1, IsVert2, x21, y21, x22, y22, k2, c2);
+
+            TempString := IntToStr(c2);
+
+            if c2 > 0 then TempString := '+' + TempString;
+
+            SortedTracks.AddObject(TempString, Prim1); // store track object using intercept as key
+        end;
+        i := i + 1;
+    end;
+
+    // pad and sort list
+    PadAndSort(SortedTracks);
+end;
+
+
+// Function to compile sorted list of vias. Note that via count checks are assumed to have been done by InitialCheck procedure
+function CompileSortedVias(const dummy : Integer) : Boolean;
+var
+    i                           : Integer;
+    TempString                  : string;
+    PrimTrack                   : IPCB_Primitive;
+    PrimVia                     : IPCB_Primitive;
+    IsIntVert                   : Boolean;
+    X, Y                        : TCoord;
+    size                        : TCoord;
+    c1                          : TCoord;
+    k1                          : Double;
+
+begin
+    Result := False;
+    if (SortedTracks = nil) or (SortedTracks.Count < 1) then exit;
+
+    SortedVias := TStringList.Create;
+
+    // iterate through selection like CompileSortedTracks, but for the two vias.
+    // Note that this will use SortedTracks list to project an intercept point for a parallel line passing through the via
+    PrimTrack :=  SortedTracks.getObject(0);
+    // populate the initial list with only vias
+    i := 0;
+    while i < Board.SelectecObjectCount do
+    begin
+        PrimVia := Board.SelectecObject[i];
+        if PrimVia.ObjectId = eViaObject then
+        begin
+            SetupDataFromVia(PrimVia, PrimTrack, k1, c1, IsIntVert, X, Y, size);
+
+            TempString := IntToStr(c1);
+
+            if c1 > 0 then TempString := '+' + TempString;
+
+            SortedVias.AddObject(TempString, PrimVia); // store track object using intercept as key
+        end;
+        i := i + 1;
+    end;
+
+    if SortedVias.Count = 2 then
+    begin
+        // pad and sort list
+        PadAndSort(SortedVias);
+        Result := True;
     end;
 end;
 
@@ -749,269 +1052,257 @@ end;
 // main procedure to distribute tracks
 procedure calculate(LaunchedFromGUI : Boolean);
 var
-    i, j                                         : Integer;
-    k1, k2                                       : Double;
-    c1, c2, minc, midc, maxc, stepc, cFromWidths : TCoord;
-    IsVert1                                      : Boolean;
-    IsVert2                                      : Boolean;
-    IsFirstPoint                                 : Boolean;
-    x11, x12, y11, y12                           : TCoord; // altium zapis koordinata
-    x21, x22, y21, y22                           : TCoord;
-    Prim1                                        : IPCB_Primitive;
-    Prim2                                        : IPCB_Primitive;
-    MaxNumOfChar                                 : Integer; // najvci broj znamenki u stringu
-    NumOfChar                                    : Integer; // broj znamenki
-    TempString                                   : string;
-    coef                                         : Double;
-    TempPresetList                               : TStringList;
+    i, j                                                    : Integer;
+    k1, k2                                                  : Double;
+    c1, c2, minc, midc, maxc, stepc, cFromWidths            : TCoord;
+    viaminc, viamaxc, viasize                               : TCoord;
+    IsVert1                                                 : Boolean;
+    IsVert2                                                 : Boolean;
+    IsFirstPoint                                            : Boolean;
+    x11, x12, y11, y12                                      : TCoord; // altium zapis koordinata
+    x21, x22, y21, y22                                      : TCoord;
+    Prim1                                                   : IPCB_Primitive;
+    Prim2                                                   : IPCB_Primitive;
+    MaxNumOfChar                                            : Integer; // najvci broj znamenki u stringu
+    NumOfChar                                               : Integer; // broj znamenki
+    TempString                                              : string;
+    coef                                                    : Double;
+    TempPresetList                                          : TStringList;
 
 begin
-    if (Board <> PCBServer.GetCurrentPCBBoard) then
-    begin
-        Showmessage('Please start script using START procedure');
-        close;
-        exit;
-    end;
-
-    if not LaunchedFromGUI then TrimPerpendicular := False; // assume don't trim if GUI wasn't used
-
-    // Board.NewUndo;
-    // Start undo
-    PCBServer.PreProcess;
-
-    // we have to sort the tracks in order because they are random (moramo srediti trackove po redu jer su izavrani random)
-    SortedTracks := TStringList.Create;
-
-    // SortedTracks.LoadFromFile('C:\');
-    // SortedTracks.Count
-
-    // populate the initial list (punjenje pocetne liste)
-    for i := 0 to Board.SelectecObjectCount - 1 do
-    begin
-        Prim1 := Board.SelectecObject[i];
-        SetupDataFromTrack(Prim1, IsVert2, x21, y21, x22, y22, k2, c2);
-
-        TempString := IntToStr(c2);
-
-        if c2 > 0 then TempString := '+' + TempString;
-
-        SortedTracks.AddObject(TempString, Prim1); // store track object using intercept as key
-    end;
-
-    // pad strings with leading zeros for sort function (Punjenje stringova nulama   radi jednakosti)
-    MaxNumOfChar := 0;
-    for i        := 0 to SortedTracks.Count - 1 do
-    begin
-        NumOfChar                                       := Length(SortedTracks.Get(i));
-        if (MaxNumOfChar < NumOfChar) then MaxNumOfChar := NumOfChar;
-    end;
-
-
-    for i := 0 to SortedTracks.Count - 1 do
-    begin
-        TempString := SortedTracks[i];
-
-        while (Length(TempString) < MaxNumOfChar) do Insert('0', TempString, 2);
-
-        SortedTracks[i] := TempString;
-    end;
-
-    SortedTracks.Sort;
-
-    // ShowMessage (SortedTracks[0][1]);  // displays the first member "0" and a string in its 1 position (prikazuje prvi clan "0" i string na njegovom 1 mjestu)
-    if (SortedTracks[SortedTracks.Count - 1][1] = '-') then
-    begin // if last track in sorted list has negative intercept
-        i := 0;
-
-        // advance i to last positive intercept
-        while (SortedTracks[i][1] = '+') do inc(i);
-
-        j := 0;
-
-        while (i < SortedTracks.Count) do
-        begin // move negative intercepts to beginning of list (before positive intercepts)
-            SortedTracks.Move(SortedTracks.Count - 1, j);
-            inc(j);
-            inc(i);
-        end;
-
-    end;
-
-    // seeks min and max c i.e. range of intercept values (trazi min i max C tj grnice sirenja   vodova)
-    // moved intercept stats here to operate on sorted data instead of original selection. doing before sorting could cause issues with distribute by clearance if first selected track is a different width.
-    Prim1 := SortedTracks.getObject(0);
-    SetupDataFromTrack(Prim1, IsVert1, x11, y11, x12, y12, k1, c1);
-
-    minc        := c1;
-    maxc        := c1;
-
-    if IsVert1 then coef := 1.0 // if first track has been coerced to vertical, coef needs to be 1 for later width compensation
-    else coef        := cos(arctan(k1)); // y-intercept coefficient based on slope (i.e. how much intercept shifts for a perpendicular shift of the track)
-
-    cFromWidths := Prim1.Width / (2 * coef); // start cFromWidths with half of the first track's width
-
-    // calculate extents of intercept values and sum of track widths in intercept units
-    for i := 1 to SortedTracks.Count - 1 do
-    begin
-        Prim1 := SortedTracks.getObject(i);
-        SetupDataFromTrack(Prim1, IsVert2, x21, y21, x22, y22, k2, c2);
-
-        if (minc > c2) then minc := c2;
-        if (maxc < c2) then maxc := c2;
-
-        cFromWidths := cFromWidths + Prim1.Width / coef; // add subsequent track widths
-    end;
-
-    cFromWidths := cFromWidths - Prim1.Width / (2 * coef); // subtract half of last track's width
-
-    midc := (Round(minc + maxc)) div 2; // midline between the outer pair of tracks
-
-    {
-        // Test case if all is good until now
-        for i := 0 to SortedTracks.Count - 1 do
+    try
+        if (Board <> PCBServer.GetCurrentPCBBoard) then
         begin
-        Prim1 := SortedTracks.GetObject(i);
-        Prim1.Selected := False;
-
-        ShowMessage(SortedTracks[i]);
-
-        Prim1.Selected := True;
+            Showmessage('Please start script using START procedure');
+            close;
+            exit;
         end;
-    }
 
-    // Add connected tracks to the track list, or pad the list if there is no track connected to a given end
-    // (Dio koji puni object listu sa susjednim trackovima ako je track onda u listu ide YES a noj stavlja NO)
-    i := 0;
-    ResetParameters;
-    AddStringParameter('Scope', 'All');
-    RunProcess('PCB:DeSelect');
-    while i < SortedTracks.Count do
-    begin
-        Prim1 := SortedTracks.getObject(i);
+        if not LaunchedFromGUI then TrimPerpendicular := False; // assume don't trim if GUI wasn't used
+
+        Board.NewUndo;
+        // if DebuggingEnabled then Board.NewUndo;
+        // Start undo
+        PCBServer.PreProcess;
+
+        // compile list of sorted tracks
+        CompileSortedTracks(0);
+
+        // seeks min and max c i.e. range of intercept values (trazi min i max C tj grnice sirenja   vodova)
+        // moved intercept stats here to operate on sorted data instead of original selection. doing before sorting could cause issues with distribute by clearance if first selected track is a different width.
+        Prim1 := SortedTracks.getObject(0);
         SetupDataFromTrack(Prim1, IsVert1, x11, y11, x12, y12, k1, c1);
 
-        // look for a track (call it track 1a) that is connected to this track's first point and insert it after this track in the list (provjera za prvu tocku i umece 1a liniju ispod 1 linije tracka)
-        Prim2 := GetAnotherTrackInPoint(Prim1, Prim1.X1, Prim1.Y1, IsFirstPoint);
+        minc        := c1;
+        maxc        := c1;
 
-        if (Prim2 = nil) then SortedTracks.Insert(i + 1, '0') // no connected track so insert placeholder
-        else
-        begin // there is a connected track, validate it
-            SetupDataFromTrack(Prim2, IsVert2, x21, y21, x22, y22, k2, c2);
-            // test whether there are any problems on the track e.g. two segments are parallel (test da li ima nekih problema na tracku npr paralelna dve u nastavku)
-            // i.e. there must be a single contiguous track segment (tj mora biti jedan jedini track)
-            if ((IsVert1 = IsVert2) and (Abs(k1 - k2) < 0.01)) then
-            begin // connected segment is parallel
-                Prim1.Selected := True;
-                Prim2.Selected := True;
-                Prim1.GraphicallyInvalidate;
-                Prim2.GraphicallyInvalidate;
+        if IsVert1 then coef := 1.0 // if first track has been coerced to vertical, coef needs to be 1 for later width compensation
+        else coef        := cos(arctan(k1)); // y-intercept coefficient based on slope (i.e. how much intercept shifts for a perpendicular shift of the track)
 
-                Showmessage('Problem on selected tracks (connected tracks are parallel - try glossing?)');
-            end;
+        cFromWidths := Prim1.Width / (2 * coef); // start cFromWidths with half of the first track's width
 
-            // insert the connected track keyed by which of its ends is connected
-            if IsFirstPoint then SortedTracks.InsertObject(i + 1, '1', Prim2)
-            else SortedTracks.InsertObject(i + 1, '2', Prim2);
-        end;
-
-        // look for another track (call it track 1b) that is connected to this track's second point and insert it after track 1a in the list.
-        // this makes a total of 3 lines: the track of interest and the two tracks connected to it, if any (Provjera za drugu tocku i umece 1b ispod linije 1a. Ukupno 3 linije)
-        Prim2 := GetAnotherTrackInPoint(Prim1, Prim1.X2, Prim1.Y2, IsFirstPoint);
-
-        if (Prim2 = nil) then SortedTracks.Insert(i + 2, '0') // no connected track so insert placeholder
-        else
-        begin // there is a connected track, validate it
-            SetupDataFromTrack(Prim2, IsVert2, x21, y21, x22, y22, k2, c2);
-
-            if ((IsVert1 = IsVert2) and (Abs(k1 - k2) < 0.01)) then
-            begin // connected segment is parallel
-                Prim1.Selected := True;
-                Prim2.Selected := True;
-                Prim1.GraphicallyInvalidate;
-                Prim2.GraphicallyInvalidate;
-
-                Showmessage('Problem on selected tracks (connected tracks are parallel - try glossing?)');
-            end;
-
-            // insert the connected track keyed by which of its ends is connected
-            if IsFirstPoint then SortedTracks.InsertObject(i + 2, '1', Prim2)
-            else SortedTracks.InsertObject(i + 2, '2', Prim2);
-        end;
-
-        i := i + 3; // jump ahead to next track of interest
-    end;
-
-    // there shouldn't be any tracks selected unless there were problems
-    if Board.SelectecObjectCount <> 0 then exit;
-
-    // all is well and about to start distributing, check if debugging is enabled
-    if DebuggingEnabled then
-    begin
-        DebugFilePath := ClientAPI_SpecialFolder_AltiumApplicationData + '\DistributeScriptDebug.csv';
-        DebugList := TStringList.Create;
-        DebugList.Append('X1 before,Y1 before,X2 before,Y2 before,slope before,intercept before,TargetSlope,TargetIntercept,X1 after,Y1 after,X2 after,Y2 after,slope after,intercept after,LastIntercept');
-    end;
-
-    if RadioButtonCenters.Checked then
-    begin
-        stepc := (maxc - minc) / ((SortedTracks.Count / 3) - 1); // intercept increment is intercept extents divided by number of tracks - 1
-        DistributeForward(minc, coef, stepc);
-    end
-    else if RadioButtonClearance.Checked then
-    begin
-        stepc := (maxc - minc - cFromWidths) / ((SortedTracks.Count / 3) - 1); // intercept increment is same as above but subtracting sum of track widths from intercept extents
-        DistributeForward(minc, coef, stepc);
-    end
-    else
-    begin // distributing using input value rather than between intercept extents
-        TempString := EditDistance.Text;
-        if (LastDelimiter(',.', TempString) <> 0) then TempString[LastDelimiter(',.', TempString)] := DecimalSeparator;
-
-        // convert desired intercept step using intercept coefficient and selected units
-        if (ButtonUnits.Caption = 'mm') then stepc := mmsToCoord(StrToFloat(TempString)) / (coef)
-        else stepc                                 := milsToCoord(StrToFloat(TempString)) / (coef);
-
-        // CALL FUNCTION to actually move the tracks
-        case RadioDirections.ItemIndex of
-            0 : DistributeForward(minc, coef, stepc);
-            1 : DistributeFromCenter(midc, coef, stepc);
-            2 : DistributeBackward(maxc, coef, stepc);
-            else DistributeForward(minc, coef, stepc);
-        end;
-    end;
-
-
-    // Stop undo
-    PCBServer.PostProcess;
-
-    if LaunchedFromGUI then
-    begin
-        // build list of currect preset values
-        TempPresetList := TStringList.Create;
-        BuildPresetList(TempPresetList);
-        if TempPresetList.Equals(PresetList) then
+        // calculate extents of intercept values and sum of track widths in intercept units
+        for i := 1 to SortedTracks.Count - 1 do
         begin
-            // presets match saved list so do nothing
+            Prim1 := SortedTracks.getObject(i);
+            SetupDataFromTrack(Prim1, IsVert2, x21, y21, x22, y22, k2, c2);
+
+            if (minc > c2) then minc := c2;
+            if (maxc < c2) then maxc := c2;
+
+            cFromWidths := cFromWidths + Prim1.Width / coef; // add subsequent track widths
+        end;
+
+        cFromWidths := cFromWidths - Prim1.Width / (2 * coef); // subtract half of last track's width
+
+        midc := (Round(minc + maxc)) div 2; // midline between the outer pair of tracks
+
+        if DebuggingEnabled then
+        begin
+            ViaDebugFilePath := ClientAPI_SpecialFolder_AltiumApplicationData + '\DistributeScriptViaDebug.csv';
+            ViaDebugList := TStringList.Create;
+            ViaDebugList.Append('Via1 X,Via1 Y,Via1 size,Via1 slope,Via1 intercept,Via2 X,Via2 Y,Via2 size,Via2 slope,Via2 intercept,ref track slope,ref track intercept, viaminc, viamaxc, midc');
+        end;
+
+        // KEY BEHAVIOR: in "CEN/VIA" distribute direction mode, via midpoint will take priority. Note that two stacked vias can be used to force a trajectory.
+        // compile list of sorted vias (MUST come after list of sorted tracks) and calculate midpoint if successful
+        // calculate midpoint accounting for via size so that differently-sized vias don't bias the result
+        if CompileSortedVias(0) then
+        begin
+            Prim2 := SortedTracks.getObject(0);         // get first track from the SortedTracks list
+
+            Prim1 := SortedVias.getObject(0);           // get first via from the SortedVias list
+            SetupDataFromVia(Prim1, Prim2, k1, c1, IsVert1, x11, y11, viasize);
+            viaminc := c1 + viasize / (2 * coef);          // add via pad radius
+
+            if DebuggingEnabled then AddToDebugListFirstVia(Prim1, Prim2);
+
+            Prim1 := SortedVias.getObject(1);           // get second via from the SortedVias list
+            SetupDataFromVia(Prim1, Prim2, k1, c1, IsVert1, x11, y11, viasize);
+            viamaxc := c1 - viasize / (2 * coef);          // subtract via pad radius
+
+            midc := (Round(viaminc + viamaxc)) div 2;   // midline between the vias, accounting for their size
+
+            if DebuggingEnabled then AddToDebugListSecondVia(Prim1, Prim2, viaminc, viamaxc, midc);
+        end;
+
+        {
+            // Test case if all is good until now
+            for i := 0 to SortedTracks.Count - 1 do
+            begin
+            Prim1 := SortedTracks.GetObject(i);
+            Prim1.Selected := False;
+
+            ShowMessage(SortedTracks[i]);
+
+            Prim1.Selected := True;
+            end;
+        }
+
+        // Add connected tracks to the track list, or pad the list if there is no track connected to a given end
+        // (Dio koji puni object listu sa susjednim trackovima ako je track onda u listu ide YES a noj stavlja NO)
+        i := 0;
+        ResetParameters;
+        AddStringParameter('Scope', 'All');
+        RunProcess('PCB:DeSelect');
+        while i < SortedTracks.Count do
+        begin
+            Prim1 := SortedTracks.getObject(i);
+            SetupDataFromTrack(Prim1, IsVert1, x11, y11, x12, y12, k1, c1);
+
+            // look for a track (call it track 1a) that is connected to this track's first point and insert it after this track in the list (provjera za prvu tocku i umece 1a liniju ispod 1 linije tracka)
+            Prim2 := GetAnotherTrackInPoint(Prim1, Prim1.X1, Prim1.Y1, IsFirstPoint);
+
+            if (Prim2 = nil) then SortedTracks.Insert(i + 1, '0') // no connected track so insert placeholder
+            else
+            begin // there is a connected track, validate it
+                SetupDataFromTrack(Prim2, IsVert2, x21, y21, x22, y22, k2, c2);
+                // test whether there are any problems on the track e.g. two segments are parallel (test da li ima nekih problema na tracku npr paralelna dve u nastavku)
+                // i.e. there must be a single contiguous track segment (tj mora biti jedan jedini track)
+                if ((IsVert1 = IsVert2) and (Abs(k1 - k2) < 0.01)) then
+                begin // connected segment is parallel
+                    Prim1.Selected := True;
+                    Prim2.Selected := True;
+                    Prim1.GraphicallyInvalidate;
+                    Prim2.GraphicallyInvalidate;
+
+                    Showmessage('Problem on selected tracks (connected tracks are parallel - try glossing?)');
+                end;
+
+                // insert the connected track keyed by which of its ends is connected
+                if IsFirstPoint then SortedTracks.InsertObject(i + 1, '1', Prim2)
+                else SortedTracks.InsertObject(i + 1, '2', Prim2);
+            end;
+
+            // look for another track (call it track 1b) that is connected to this track's second point and insert it after track 1a in the list.
+            // this makes a total of 3 lines: the track of interest and the two tracks connected to it, if any (Provjera za drugu tocku i umece 1b ispod linije 1a. Ukupno 3 linije)
+            Prim2 := GetAnotherTrackInPoint(Prim1, Prim1.X2, Prim1.Y2, IsFirstPoint);
+
+            if (Prim2 = nil) then SortedTracks.Insert(i + 2, '0') // no connected track so insert placeholder
+            else
+            begin // there is a connected track, validate it
+                SetupDataFromTrack(Prim2, IsVert2, x21, y21, x22, y22, k2, c2);
+
+                if ((IsVert1 = IsVert2) and (Abs(k1 - k2) < 0.01)) then
+                begin // connected segment is parallel
+                    Prim1.Selected := True;
+                    Prim2.Selected := True;
+                    Prim1.GraphicallyInvalidate;
+                    Prim2.GraphicallyInvalidate;
+
+                    Showmessage('Problem on selected tracks (connected tracks are parallel - try glossing?)');
+                end;
+
+                // insert the connected track keyed by which of its ends is connected
+                if IsFirstPoint then SortedTracks.InsertObject(i + 2, '1', Prim2)
+                else SortedTracks.InsertObject(i + 2, '2', Prim2);
+            end;
+
+            i := i + 3; // jump ahead to next track of interest
+        end;
+
+        // there shouldn't be any tracks selected unless there were problems
+        if Board.SelectecObjectCount <> 0 then exit;
+
+        // all is well and about to start distributing, check if debugging is enabled
+        if DebuggingEnabled then
+        begin
+            DebugFilePath := ClientAPI_SpecialFolder_AltiumApplicationData + '\DistributeScriptDebug.csv';
+            DebugList := TStringList.Create;
+            DebugList.Append('X1 before,Y1 before,X2 before,Y2 before,slope before,intercept before,TargetSlope,TargetIntercept,X1 after,Y1 after,X2 after,Y2 after,slope after,intercept after,LastIntercept');
+        end;
+
+        if RadioButtonCenters.Checked then
+        begin
+            stepc := (maxc - minc) / ((SortedTracks.Count / 3) - 1); // intercept increment is intercept extents divided by number of tracks - 1
+            DistributeForward(minc, coef, stepc);
+        end
+        else if RadioButtonClearance.Checked then
+        begin
+            stepc := (maxc - minc - cFromWidths) / ((SortedTracks.Count / 3) - 1); // intercept increment is same as above but subtracting sum of track widths from intercept extents
+            DistributeForward(minc, coef, stepc);
         end
         else
-        begin
-            // save new list to MyDistributePresets.txt
-            TempPresetList.SaveToFile(PresetFilePath);
+        begin // distributing using input value rather than between intercept extents
+            TempString := EditDistance.Text;
+            if (LastDelimiter(',.', TempString) <> 0) then TempString[LastDelimiter(',.', TempString)] := DecimalSeparator;
+
+            // convert desired intercept step using intercept coefficient and selected units
+            if (ButtonUnits.Caption = 'mm') then stepc := mmsToCoord(StrToFloat(TempString)) / (coef)
+            else stepc                                 := milsToCoord(StrToFloat(TempString)) / (coef);
+
+            // CALL FUNCTION to actually move the tracks
+            case RadioDirections.ItemIndex of
+                0 : DistributeForward(minc, coef, stepc);
+                1 : DistributeFromCenter(midc, coef, stepc);
+                2 : DistributeBackward(maxc, coef, stepc);
+                else DistributeForward(minc, coef, stepc);
+            end;
         end;
 
+        if LaunchedFromGUI then
+        begin
+            // build list of currect preset values
+            TempPresetList := TStringList.Create;
+            BuildPresetList(TempPresetList);
+            if TempPresetList.Equals(PresetList) then
+            begin
+                // presets match saved list so do nothing
+            end
+            else
+            begin
+                // save new list to MyDistributePresets.txt
+                TempPresetList.SaveToFile(PresetFilePath);
+            end;
+
+        end;
+
+        if DebuggingEnabled then
+        begin
+            ViaDebugList.SaveToFile(ViaDebugFilePath);
+            DebugList.SaveToFile(DebugFilePath);
+            ShowMessage('Debugging output saved');
+        end;
+
+    finally
+        // Stop undo
+        PCBServer.PostProcess;
+
         // cleanup
+        SortedTracks.Free;
+        SortedVias.Free;
         TempPresetList.Free;
         PresetList.Free;
-    end;
 
-    if DebuggingEnabled then
-    begin
-        DebugList.SaveToFile(DebugFilePath);
-        DebugList.Free;
-        ShowMessage('Debugging output saved');
-    end;
+        if DebuggingEnabled then
+        begin
+            DebugList.Free;
+            ViaDebugList.Free;
+        end;
 
-    close;
+        close;
+
+    end;
 end;
 
 
@@ -1227,7 +1518,8 @@ begin
     // Set direction control hint
     Application.HintHidePause := 11000; // extend hint show time
     RadioDirections.Hint      := 'FWD: The original direction that the distribute script spreads tracks.' + sLineBreak +
-        'CEN: Redistributes tracks from the center of extents. For example, a pair of tracks will move symmetrically.' + sLineBreak +
+        'CEN/VIA: Redistributes tracks from the center of extents or the midpoint between two vias.' + sLineBreak +
+        'CEN/VIA examples: a pair of tracks and no vias will move symmetrically; a single track with two vias will center the track between vias.' + sLineBreak +
         'REV: Will reverse the direction of distribution i.e. what would normally be the last track is instead the first track.';
 
     // read presets from file

--- a/Scripts - PCB/Distribute/README.md
+++ b/Scripts - PCB/Distribute/README.md
@@ -67,4 +67,4 @@ Tracks with a slope greater than 20 (90° > angle > ~87.137°) will be coerced t
 
 2022-11-18 by Ryan Rutledge : v1.44 - fixed bug where near-vertical tracks wouldn't trim properly if ends were normalized; fixed overflow error for steep angles; fixed invalid distribution if tracks are near vertical and are coerced to vertical
 
-2023-04-11 by Ryan Rutledge : v1.45 - added ability for _CEN_ distribution direction to center track(s) between vias if exactly 2 vias are selected (takes priority over track-derived centerline)
+2023-04-11 by Ryan Rutledge : v1.45 - added ability for _CEN_ distribution direction to center track(s) between vias if exactly 2 vias are selected (takes priority over track-derived centerline); fixed redundant move in _CEN_ distribute that could cause coerced middle track to be set to zero length

--- a/Scripts - PCB/Distribute/README.md
+++ b/Scripts - PCB/Distribute/README.md
@@ -35,7 +35,8 @@ For the _CEN_ Direction mode, _First Track_ is either the middle track if there 
 
 ### Direction of distribution
 _FWD_ behaves as described above, which is the same behavior as previous versions of the script.\
-_CEN_ redistributes tracks from the center of extents. For example, a pair of tracks will move symmetrically. The center line is halfway between the outer pair of tracks.\
+_CEN_ redistributes tracks from the midpoint between two vias **OR** from the center of extents. For example, a pair of tracks will move symmetrically or a single track plus two vias will center the track between the vias. The center line is midway between the two selected vias or halfway between the outer pair of tracks' centerlines.\
+* **Tip:** stack 2 vias on top of each other to force the center to intersect them.\
 _REV_ will reverse the direction of distribution i.e. what would normally be the last track is instead the first track.
 ### Changing Units
 When one of the by-value options is active, clicking the "mil" label next to the input value will change it to "MM" and vice versa.
@@ -65,3 +66,5 @@ Tracks with a slope greater than 20 (90° > angle > ~87.137°) will be coerced t
 2022-11-17 by Ryan Rutledge : v1.43 - added debugging tools; fixed TargetSlope getting reset for each track instead of set once by _First Track_
 
 2022-11-18 by Ryan Rutledge : v1.44 - fixed bug where near-vertical tracks wouldn't trim properly if ends were normalized; fixed overflow error for steep angles; fixed invalid distribution if tracks are near vertical and are coerced to vertical
+
+2023-04-11 by Ryan Rutledge : v1.45 - added ability for _CEN_ distribution direction to center track(s) between vias if exactly 2 vias are selected (takes priority over track-derived centerline)


### PR DESCRIPTION
- Added option to _CEN_ distribute direction mode to allow centering between vias
- Fixed redundant move of middle track during _CEN_ distribute reverse pass that could result in setting track to zero length
- Added some safety checks around resource allocation and freeing to avoid ungraceful script termination causing problems
- Refactored some of the main `calculate` code into functions