### PR TITLE
AssemblyTextPrep_v0.86 bug fix

### DIFF
--- a/Scripts - PCB/AssemblyTextPrep/AssemblyTextPrep.pas
+++ b/Scripts - PCB/AssemblyTextPrep/AssemblyTextPrep.pas
@@ -5,7 +5,7 @@ const
     cMaxMechLayers          = 1024;
     cScriptTitle            = 'AssemblyTextPrep';
     cConfigFileName         = 'AssemblyTextPrepConfig.ini';
-    cScriptVersion          = '0.85';
+    cScriptVersion          = '0.86';
     cDEBUGLEVEL             = 0;
 
     DEBUGEXPANSION          = -1; // leave at -1 to disable
@@ -246,6 +246,7 @@ begin
     begin
         // copy properties of example assy designator
         CopyTextFormatFromTo(StyleText, NewTextObj);
+        NewTextObj.AdvanceSnapping          := True;
         NewTextObj.XLocation                := Comp.x;
         NewTextObj.YLocation                := Comp.y;
         NewTextObj.TTFInvertedTextJustify   := eAutoPos_CenterCenter;

--- a/Scripts - PCB/AssemblyTextPrep/README.md
+++ b/Scripts - PCB/AssemblyTextPrep/README.md
@@ -75,3 +75,4 @@ There might be some value in adding a function to check that all components *hav
 - 2023-07-28 by Ryan Rutledge : AssemblyTextPrep v0.83 - added option to protect locked .Designator strings; bug fixes
 - 2023-08-02 by Ryan Rutledge : AssemblyTextPrep v0.84 - fixed AdvanceSnapping missing from string normalization function; fixed undo on normalize any text button; fixed normalize assy text button
 - 2023-08-24 by Ryan Rutledge : AssemblyTextPrep v0.85 - fixed missing debug function throwing error
+- 2023-09-11 by Ryan Rutledge : AssemblyTextPrep v0.86 - fixed possible bug with `AddAssyTextToCompFromStyle` when style template has `.AdvanceSnapping = False`


### PR DESCRIPTION
fixed possible bug with `AddAssyTextToCompFromStyle` when style template has `.AdvanceSnapping = False`