### PR TITLE
FindUnmatchedPorts v1.10 adds detection of mixed port names

### DIFF
--- a/Scripts - SCH/FindUnmatchedPorts/README.md
+++ b/Scripts - SCH/FindUnmatchedPorts/README.md
@@ -31,3 +31,4 @@ Script will also report any nets that have an "invalid" combination of port dire
 
 ## Changelog
 - 2023-12-05 by Corey Beyer & Ryan Rutledge : v1.00 - Initial release based on Corey's FindFloatingPorts v1.1
+- 2023-12-07 by Ryan Rutledge : v1.10 - added support for detecting when a net has mixed port names (sometimes this is intentional!); unmatched ports list will now ignore floating ports (if they were previously identified)


### PR DESCRIPTION
Port names are considered mixed when the ports in a given net have more than one unique port name. This is common in hierarchical schematics, for example when a re-used sheet uses a generic port name.