### PR TITLE
PCBObjectInspector v0.40 adds compare function and coord unit conversion

### DIFF
--- a/Scripts - PCB/PCBObjectInspector/README.md
+++ b/Scripts - PCB/PCBObjectInspector/README.md
@@ -18,9 +18,11 @@ _Step 3_: Select objects on the PcbDoc and run `_Inspect` script procedure.
 - `TurnOnAdvanceSnapping` : Turns **ON** the `AdvanceSnapping` property of PCB Text strings. Can fix certain text snap point and justification issues.
 - `MeasureThicknessBetween` : Measures board thickness between two objects on different layers, or between start and stop layers of multilayer pads or vias. Thickness measurement includes thickness of metal layers *between* start and stop layers.
 - `LayerStackSummary` : Demonstrates getting a list of all layers from top to bottom in the stackup with a custom formatted summary and the layer objects themselves.
-- `Inspect_CallBackHyperlinkText_ZoomPCB` : Demonstrates creating an HTML hyperlink for the selected PCB object(s)
+- `Inspect_CallBackHyperlinkText_ZoomPCB` : Demonstrates creating an HTML hyperlink for the selected PCB object(s).
+- `CompareObjects` : Compares inspector results between two objects of the same type and shows differences.
 
 ## Change log
+- 2024-01-11 by Ryan Rutledge : v0.40 - added ability to compare inspector results between two of the same type of object; most Coord values will now also show display unit values (X and Y coordinates are converted relative to board origin); changed to using custom rounding for coordinate to string conversions
 - 2024-01-10 by Ryan Rutledge : v0.32 - improved connection checking routine; added demonstration of creating an HTML hyperlink to jump to a PCB object in Altium Designer; added display unit conversion functions with rounding
 - 2023-12-21 by Ryan Rutledge : v0.31 - some polishing; added function to measure board thickness between layers; added function to build a list of stackup layer objects from a given start to stop layer
 - 2023-12-20 by Ryan Rutledge : v0.30 - fixed some bugs; changed layer numbers to strings; added function to determine the layers a pad or via has wired connections on (working on this for ReturnViaCheck script, but this script makes for easy testing and debugging of utility functions)


### PR DESCRIPTION
- added ability to compare inspector results between two of the same type of object
- most Coord values will now also show display unit values (X and Y coordinates are converted relative to board origin)
- changed to using custom rounding for coordinate to string conversions
- other cleanup