### PR TITLE
QuickSilk v1.13 fixes bugs

### DIFF
--- a/Scripts - PCB/QuickSilk/QuickSilk.pas
+++ b/Scripts - PCB/QuickSilk/QuickSilk.pas
@@ -26,7 +26,7 @@ const
     cCtrlKey            = 3; // available for use during component and location selection
     cConfigFileName     = 'QuickSilkSettings.ini';
     cScriptTitle        = 'QuickSilk';
-    cScriptVersion      = '1.12';
+    cScriptVersion      = '1.13';
     cDEBUGLEVEL         = 0;
 
 var
@@ -845,7 +845,9 @@ var
     ConfigDebugCaption  : String;
     SettingsDebugFile   : String;
     SettingsDebugList   : TStringList;
+    NewSettings         : Boolean;
 begin
+    NewSettings := False;
     LocalSettingsFile := ExtractFilePath(GetRunningScriptProjectName) + cConfigFileName;
 
     // set CheckBoxLocalSettings.Checked to true if local settings file exists
@@ -869,12 +871,14 @@ begin
     // Check for old MoveAPdesignators2 file if the provided file doesn't exist
     if not FileExists(AFileName) then
     begin
+        NewSettings := True; // set flag to immediately save default settings
+
         AFileName := ClientAPI_SpecialFolder_AltiumApplicationData + '\MoveAPdesignators2Settings.ini';
         if not FileExists(AFileName) then
         begin
             // ini file doesn't exist, try to fall back on even older format file
             LoadPresetListFromFile(0);
-            exit;
+            //exit; // don't actually need to exit if fallback happens, just override defaults if used
         end;
     end;
 
@@ -950,6 +954,8 @@ begin
     finally
         IniFile.Free;
     end;
+
+    if NewSettings then ConfigFile_Write(ConfigFile_GetPath);
 end;
 
 procedure   ConfigFile_Write(AFileName : String);
@@ -1478,9 +1484,9 @@ begin
             else if InSet(cCtrlKey, LocKeySet) then ParentOnly := False else ParentOnly := True; // hold CTRL to also avoid things that are outside parent component
             DebugMessage(3, 'Begin: IsValidPlacement=' + BoolToStr(IsValidPlacement(NameOrComment, ParentOnly), True));
 
-            MoveDist := AutoMove(NameOrComment, ParentOnly, 200000, tc_Autopos);
-
             NormalizeText(NameOrComment);
+
+            MoveDist := AutoMove(NameOrComment, ParentOnly, 200000, tc_Autopos);
 
             NameOrComment.GraphicallyInvalidate;
 

--- a/Scripts - PCB/QuickSilk/README.md
+++ b/Scripts - PCB/QuickSilk/README.md
@@ -104,41 +104,10 @@ From the GUI, you may click on the clearance labels to select all visible design
 - Added ability to select designators or comments under component bodies, etc.
 
 # Changelog
-- 2022-11-28 - MoveAPdesignators2 Ver 2.0 : Initial release based on MoveAPdesignators scrip Ver 1.2; uses new string justification settings and fixed bug with designator not actually moving coords; added presets and restore last used values
-- 2022-11-28 - MoveAPdesignators2 Ver 2.01 : fixed justification for rotated strings (approximated to nearest 90° rotation)
-- 2022-11-28 - MoveAPdesignators2 Ver 2.02 : *actually* fixed justification for rotated strings (I think)
-- 2022-11-28 - MoveAPdesignators2 Ver 2.03 : ***actually*** *actually* fixed justification and movement for rotated strings (my test PcbDoc was glitched where bottom side designators were mirrored in place or something)
-- 2023-02-15 - MoveAPdesignators2 Ver 2.04 : fixed support for moving designators away with negative input value; maybe, *possibly*, ***actually*** fixed justification and movement for the last time (*found a bug in Altium where components flipped to the other side of the board have the wrong autoposition behavior until the PcbDoc is closed and re-opened.*)
-- 2023-06-20 - MoveAPdesignators2 Ver 2.05 : added support for initially selecting a mix of designators and components, rather than only components; added support for AD19+ AdvanceSnapping text property (might actually fix previous justification bug); better memory safety
-- 2023-07-04 - MoveAPdesignators2 Ver 2.06 : 
-    - added automatic movement amount support
-    - added command (no GUI) to interactively adjust Designator Autoposition setting for components (with automove)
-    - improved clearance detection to use object outlines instead of bounding boxes for most things (better support for objects that aren't at 0/90)
-    - reworked configuration file to use .ini file instead, for better forward compatibility
-- 2023-07-05 - MoveAPdesignators2 Ver 2.07 : added button to GUI to start interactive placement tool; added redundant `Start` procedure for users that are accustomed to using that
-- 2023-07-05 - MoveAPdesignators2 Ver 2.08 : fixed issue with interactive placement tool being flipped horizontally for bottom side components
-- 2023-07-06 - MoveAPdesignators2 Ver 2.09 : (Interactive placement) added ability to target locked components
-- 2023-07-11 - MoveAPdesignators2 Ver 2.10 : (Interactive placement) reworked text rotation to be 0° or 90° relative to part rotation (i.e. normal or orthogonal to part, not board); **autoposition now supports any placement angle**
-- 2023-07-13 - MoveAPdesignators2 Ver 2.11 : 
-    - (interactive placement, when other components NOT ignored) will try up to 30 mils (in 5mil steps) of nudging in each perpendicular direction to try to find a passing solution
-    - Cursor will change when picking component, picking location, and when AutoMove is processing
-    - Visible grid will be set to 5mil or 0.1mm at start of interactive placement as large grid can mess things up
-- 2023-07-14 - QuickSilk Ver 1.00 : Renamed to "QuickSilk"
-    - fixed issue where component could be picked if some of its layers were visible (eg silkscreen) even though its copper layer was hidden. Intended behavior is that only components whose COPPER layer is enabled will be selectable.
-    - clearance constraints are now configurable through GUI
-    - main GUI now includes configuration values
-    - improved cursor lag issue
-- 2023-07-16 - QuickSilk Ver 1.01 : optimization and polish pass
-    - added quicker nudging routine when avoiding all objects (exhaustive search fallback is available as "Try Extra Offsets" config option)
-    - added separate clearance mode option for mass AutoMove
-    - GUI polish
-- 2023-07-17 - QuickSilk Ver 1.02 : added ability to save settings to script folder
-- 2023-07-17 - QuickSilk Ver 1.03 : fixed bug in v1.00 that broke Any-Angle OFF placement
-- 2023-07-18 - QuickSilk Ver 1.04 : added ability to center and hide Designator/Comment with ALT+RMB; attempted to improve picker responsiveness
-- 2023-07-18 - QuickSilk Ver 1.05 : removed "selected only" from saved settings and instead default to it any time GUI is launched with components selected; added messages when components are skipped because their autopositions are not eligible for moving
-- 2023-07-22 - QuickSilk Ver 1.06 : (GUI enhancement) added ability to select any Designators or Comments that violate a clearance rule; (performance) made AutoMove even more automatic by adjusting search range according to component size
-- 2023-07-22 - QuickSilk Ver 1.07 : fixed bug where GUI could run clearance check or automove with stale clearance values from startup
-- 2023-07-24 - QuickSilk Ver 1.08 : added support for avoiding vias with their own clearance rule
+- 2024-01-22 - QuickSilk Ver 1.13 : fixed needing to run GUI at least once; fixed text normalization to happen before autopositioning
+- 2023-12-07 - QuickSilk Ver 1.12 : added nearness-to-click tie-breaker for locked components that have the same bounding area
+- 2023-08-01 - QuickSilk Ver 1.11 : fixed bug where first component body found would be ignored
+- 2023-08-01 - QuickSilk Ver 1.10 : modified so that "current layer" priority of component picker considers silkscreen layers' side too
 - 2023-07-28 - QuickSilk Ver 1.09 : bug fixes, UX improvements, progress bar
     - GUI is no longer modal, allowing you to run clearance checks without starting script multiple times (however, see known 3D mouse issue)
     - added support for via clearance from holes
@@ -148,9 +117,41 @@ From the GUI, you may click on the clearance labels to select all visible design
     - fixed All Objects clearance check not including vias
     - made clearance check zoom to selected optional
     - changed area around text to look for violations from fixed 20 mils to whatever clearance rule is that's being checked
-- 2023-08-01 - QuickSilk Ver 1.10 : modified so that "current layer" priority of component picker considers silkscreen layers' side too
-- 2023-08-01 - QuickSilk Ver 1.11 : fixed bug where first component body found would be ignored
-- 2023-12-07 - QuickSilk Ver 1.12 : added nearness-to-click tie-breaker for locked components that have the same bounding area
+- 2023-07-24 - QuickSilk Ver 1.08 : added support for avoiding vias with their own clearance rule
+- 2023-07-22 - QuickSilk Ver 1.07 : fixed bug where GUI could run clearance check or automove with stale clearance values from startup
+- 2023-07-22 - QuickSilk Ver 1.06 : (GUI enhancement) added ability to select any Designators or Comments that violate a clearance rule; (performance) made AutoMove even more automatic by adjusting search range according to component size
+- 2023-07-18 - QuickSilk Ver 1.05 : removed "selected only" from saved settings and instead default to it any time GUI is launched with components selected; added messages when components are skipped because their autopositions are not eligible for moving
+- 2023-07-18 - QuickSilk Ver 1.04 : added ability to center and hide Designator/Comment with ALT+RMB; attempted to improve picker responsiveness
+- 2023-07-17 - QuickSilk Ver 1.03 : fixed bug in v1.00 that broke Any-Angle OFF placement
+- 2023-07-17 - QuickSilk Ver 1.02 : added ability to save settings to script folder
+- 2023-07-16 - QuickSilk Ver 1.01 : optimization and polish pass
+    - added quicker nudging routine when avoiding all objects (exhaustive search fallback is available as "Try Extra Offsets" config option)
+    - added separate clearance mode option for mass AutoMove
+    - GUI polish
+- 2023-07-14 - QuickSilk Ver 1.00 : Renamed to "QuickSilk"
+    - fixed issue where component could be picked if some of its layers were visible (eg silkscreen) even though its copper layer was hidden. Intended behavior is that only components whose COPPER layer is enabled will be selectable.
+    - clearance constraints are now configurable through GUI
+    - main GUI now includes configuration values
+    - improved cursor lag issue
+- 2023-07-13 - MoveAPdesignators2 Ver 2.11 : 
+    - (interactive placement, when other components NOT ignored) will try up to 30 mils (in 5mil steps) of nudging in each perpendicular direction to try to find a passing solution
+    - Cursor will change when picking component, picking location, and when AutoMove is processing
+    - Visible grid will be set to 5mil or 0.1mm at start of interactive placement as large grid can mess things up
+- 2023-07-11 - MoveAPdesignators2 Ver 2.10 : (Interactive placement) reworked text rotation to be 0° or 90° relative to part rotation (i.e. normal or orthogonal to part, not board); **autoposition now supports any placement angle**
+- 2023-07-06 - MoveAPdesignators2 Ver 2.09 : (Interactive placement) added ability to target locked components
+- 2023-07-05 - MoveAPdesignators2 Ver 2.08 : fixed issue with interactive placement tool being flipped horizontally for bottom side components
+- 2023-07-05 - MoveAPdesignators2 Ver 2.07 : added button to GUI to start interactive placement tool; added redundant `Start` procedure for users that are accustomed to using that
+- 2023-07-04 - MoveAPdesignators2 Ver 2.06 : 
+    - added automatic movement amount support
+    - added command (no GUI) to interactively adjust Designator Autoposition setting for components (with automove)
+    - improved clearance detection to use object outlines instead of bounding boxes for most things (better support for objects that aren't at 0/90)
+    - reworked configuration file to use .ini file instead, for better forward compatibility
+- 2023-06-20 - MoveAPdesignators2 Ver 2.05 : added support for initially selecting a mix of designators and components, rather than only components; added support for AD19+ AdvanceSnapping text property (might actually fix previous justification bug); better memory safety
+- 2023-02-15 - MoveAPdesignators2 Ver 2.04 : fixed support for moving designators away with negative input value; maybe, *possibly*, ***actually*** fixed justification and movement for the last time (*found a bug in Altium where components flipped to the other side of the board have the wrong autoposition behavior until the PcbDoc is closed and re-opened.*)
+- 2022-11-28 - MoveAPdesignators2 Ver 2.03 : ***actually*** *actually* fixed justification and movement for rotated strings (my test PcbDoc was glitched where bottom side designators were mirrored in place or something)
+- 2022-11-28 - MoveAPdesignators2 Ver 2.02 : *actually* fixed justification for rotated strings (I think)
+- 2022-11-28 - MoveAPdesignators2 Ver 2.01 : fixed justification for rotated strings (approximated to nearest 90° rotation)
+- 2022-11-28 - MoveAPdesignators2 Ver 2.0 : Initial release based on MoveAPdesignators scrip Ver 1.2; uses new string justification settings and fixed bug with designator not actually moving coords; added presets and restore last used values
 
 ### Planned features?
 - Add violating objects to messages panel with ability to jump to?


### PR DESCRIPTION
- fixed needing to run GUI at least once
- fixed text normalization to happen before autopositioning (else clearance was being checked in default rotation, not final rotation)