### PR TITLE
Scripts PCB - RenumberPads - Added Prefix, Suffix, and Preview Button

### DIFF
--- a/Scripts - PCB/RenumberPads/RenumberPads.dfm
+++ b/Scripts - PCB/RenumberPads/RenumberPads.dfm
@@ -3,8 +3,8 @@ object RenumberPads: TRenumberPads
   Top = 0
   BorderIcons = [biSystemMenu]
   Caption = 'Renumber Pads'
-  ClientHeight = 145
-  ClientWidth = 298
+  ClientHeight = 278
+  ClientWidth = 247
   Color = clBtnFace
   DragMode = dmAutomatic
   Font.Charset = DEFAULT_CHARSET
@@ -22,61 +22,124 @@ object RenumberPads: TRenumberPads
   object GroupBox: TGroupBox
     Left = 8
     Top = 8
-    Width = 280
-    Height = 128
+    Width = 232
+    Height = 220
     Caption = 'Renumber setup'
     TabOrder = 0
     object lblFirstPadIndex: TLabel
-      Left = 32
-      Top = 29
-      Width = 73
-      Height = 13
+      Left = 20
+      Top = 20
+      Width = 100
+      Height = 25
       Caption = 'First Pad Index'
     end
     object lblPadIncrement: TLabel
-      Left = 32
-      Top = 60
-      Width = 101
-      Height = 13
+      Left = 20
+      Top = 50
+      Width = 100
+      Height = 25
       Caption = 'Pad Index Increment'
     end
+    object lblPreview: TLabel
+      Left = 182
+      Top = 160
+      Width = 38
+      Height = 13
+      Alignment = taRightJustify
+      Caption = 'Preview'
+      Layout = tlCenter
+      Visible = False
+    end
     object edFirstPadNumber: TEdit
-      Left = 160
-      Top = 24
-      Width = 81
-      Height = 21
+      Left = 140
+      Top = 20
+      Width = 80
+      Height = 24
+      Hint = 'Enter starting designator index.'
       Alignment = taRightJustify
       NumbersOnly = True
       TabOrder = 0
       Text = '1'
     end
     object btnOK: TButton
-      Left = 40
-      Top = 88
-      Width = 75
+      Left = 20
+      Top = 190
+      Width = 80
       Height = 25
       Caption = 'OK'
       TabOrder = 2
       OnClick = btnOKClick
     end
     object btnCancel: TButton
-      Left = 168
-      Top = 88
-      Width = 75
+      Left = 140
+      Top = 190
+      Width = 80
       Height = 25
       Caption = 'Cancel'
       TabOrder = 3
       OnClick = btnCancelClick
     end
     object edPadIncrement: TEdit
-      Left = 160
-      Top = 56
-      Width = 81
-      Height = 21
+      Left = 140
+      Top = 50
+      Width = 80
+      Height = 24
+      Hint = 'Enter designator incrementing index.'
       Alignment = taRightJustify
       NumbersOnly = True
       TabOrder = 1
       Text = '1'
+    end
+    object cbPrefix: TCheckBox
+      Left = 20
+      Top = 80
+      Width = 100
+      Height = 25
+      Hint = 'Enable designator prefix.'
+      Caption = 'Prefix'
+      TabOrder = 4
+      OnClick = cbPrefixClick
+    end
+    object cbSuffix: TCheckBox
+      Left = 20
+      Top = 110
+      Width = 100
+      Height = 25
+      Hint = 'Enable designator suffix.'
+      Caption = 'Suffix'
+      TabOrder = 5
+      OnClick = cbSuffixClick
+    end
+    object edPrefix: TEdit
+      Left = 140
+      Top = 80
+      Width = 80
+      Height = 25
+      Hint = 'Enter designator prefix.'
+      Alignment = taRightJustify
+      Enabled = False
+      TabOrder = 6
+      Text = 'A'
+    end
+    object edSuffix: TEdit
+      Left = 140
+      Top = 110
+      Width = 80
+      Height = 25
+      Hint = 'Enter designator suffix.'
+      Alignment = taRightJustify
+      Enabled = False
+      TabOrder = 7
+      Text = 'A'
+    end
+    object btnPreview: TButton
+      Left = 20
+      Top = 160
+      Width = 80
+      Height = 25
+      Caption = 'Preview'
+      TabOrder = 8
+      OnClick = btnPreviewClick
     end
   end
 end

--- a/Scripts - PCB/RenumberPads/RenumberPads.dfm
+++ b/Scripts - PCB/RenumberPads/RenumberPads.dfm
@@ -29,15 +29,15 @@ object RenumberPads: TRenumberPads
     object lblFirstPadIndex: TLabel
       Left = 20
       Top = 20
-      Width = 100
-      Height = 25
+      Width = 73
+      Height = 13
       Caption = 'First Pad Index'
     end
     object lblPadIncrement: TLabel
       Left = 20
       Top = 50
-      Width = 100
-      Height = 25
+      Width = 101
+      Height = 13
       Caption = 'Pad Index Increment'
     end
     object lblPreview: TLabel
@@ -54,7 +54,7 @@ object RenumberPads: TRenumberPads
       Left = 140
       Top = 20
       Width = 80
-      Height = 24
+      Height = 21
       Hint = 'Enter starting designator index.'
       Alignment = taRightJustify
       NumbersOnly = True
@@ -83,7 +83,7 @@ object RenumberPads: TRenumberPads
       Left = 140
       Top = 50
       Width = 80
-      Height = 24
+      Height = 21
       Hint = 'Enter designator incrementing index.'
       Alignment = taRightJustify
       NumbersOnly = True
@@ -114,7 +114,7 @@ object RenumberPads: TRenumberPads
       Left = 140
       Top = 80
       Width = 80
-      Height = 25
+      Height = 21
       Hint = 'Enter designator prefix.'
       Alignment = taRightJustify
       Enabled = False
@@ -125,7 +125,7 @@ object RenumberPads: TRenumberPads
       Left = 140
       Top = 110
       Width = 80
-      Height = 25
+      Height = 21
       Hint = 'Enter designator suffix.'
       Alignment = taRightJustify
       Enabled = False

--- a/Scripts - PCB/RenumberPads/RenumberPads.pas
+++ b/Scripts - PCB/RenumberPads/RenumberPads.pas
@@ -20,12 +20,24 @@ procedure TRenumberPads.btnOKClick(Sender: TObject);
 Var
     PadIndex     : Integer;
     PadIncrement : Integer;
+    PadPrefix    : String;
+    PadSuffix    : String;
+    PadDesignator : String;
 
 Begin
 
-     // Get requested first index number
+     // Get requested first index number.
     PadIndex := StrToInt(edFirstPadNumber.Text);
     PadIncrement := StrToInt(edPadIncrement.Text);
+
+    // Get requested prefix and suffix, if enabled.
+    if cbPrefix.Checked then PadPrefix := edPrefix.Text
+    else PadPrefix := '';
+
+    if cbSuffix.Checked then PadSuffix := edSuffix.Text
+    else PadSuffix := '';
+
+    // Hide window.
     RenumberPads.Visible := 0;
 
      // Ask user to select first pad object
@@ -38,13 +50,15 @@ Begin
         PCBServer.SendMessageToRobots(PadObject.I_ObjectAddress, c_Broadcast,
                                PCBM_BeginModify , c_NoEventData);
          // change pad index
-        PadObject.Name := PadIndex;
+        PadObject.Name := format('%S%S%S',[PadPrefix, IntToStr(PadIndex), PadSuffix]);
         PCBServer.SendMessageToRobots(PadObject.I_ObjectAddress, c_Broadcast,
                                PCBM_EndModify , c_NoEventData);
         PCBServer.PostProcess;
 
+        // Increment the current pad index for the next loop.
         PadIndex := PadIndex + PadIncrement;
-         // ask user to select next pad in infinite loop
+
+        // Ask user to select next pad in infinite loop.
         PadObject := Board.GetObjectAtCursor(MkSet(ePadObject), AllLayers,
                                       'Choose a pad');
     End;
@@ -53,7 +67,7 @@ Begin
 End;
 
 
-
+// Cancel button event.
 procedure TRenumberPads.btnCancelClick(Sender: TObject);
 begin
      Close;
@@ -77,3 +91,46 @@ begin
 
 end;
 
+
+// Enable or disable the designator prefix option.
+procedure TRenumberPads.cbPrefixClick(Sender: TObject);
+begin
+     if cbPrefix.Checked then edPrefix.Enabled := True
+     else edPrefix.Enabled := False;
+end;
+
+
+// Enable or disable the designator suffix option.
+procedure TRenumberPads.cbSuffixClick(Sender: TObject);
+begin
+     if cbSuffix.Checked then edSuffix.Enabled := True
+     else edSuffix.Enabled := False;
+end;
+
+
+// Generate a preview of the designator format.
+procedure TRenumberPads.btnPreviewClick(Sender: TObject);
+Var
+     PadIndex     : Integer;
+     PadIncrement : Integer;
+     PadPrefix    : String;
+     PadSuffix    : String;
+     PadDesignator : String;
+     PadDesignatorNext      : String;
+
+begin
+     PadIndex := StrToInt(edFirstPadNumber.Text);
+     PadIncrement := StrToInt(edPadIncrement.Text);
+
+     if cbPrefix.Checked then PadPrefix := edPrefix.Text
+     else PadPrefix := '';
+
+     if cbSuffix.Checked then PadSuffix := edSuffix.Text
+     else PadSuffix := '';
+
+     lblPreview.Visible := True;
+
+     PadDesignator := format('%S%S%S',[PadPrefix, IntToStr(PadIndex), PadSuffix]);
+     PadDesignatorNext := format('%S%S%S',[PadPrefix, IntToStr(PadIndex + PadIncrement), PadSuffix]);
+     lblPreview.Caption := format('%S, %S', [PadDesignator, PadDesignatorNext]);
+end;

--- a/Scripts - PCB/RenumberPads/RenumberPads.pas
+++ b/Scripts - PCB/RenumberPads/RenumberPads.pas
@@ -16,6 +16,9 @@ Var
     PadObject   : IPCB_Pad;
 
 {..............................................................................}
+
+
+// OK button event.
 procedure TRenumberPads.btnOKClick(Sender: TObject);
 Var
     PadIndex     : Integer;


### PR DESCRIPTION
Added the ability to enable/disable a prefix and/or suffix that can be added to the designator.
This is especially helpful when copy/pasting pads in array land patterns such as BGAs, LGAs, and some connectors.

![image](https://github.com/user-attachments/assets/16e2ac60-9421-4df3-b621-51644260fd38)

A preview button has been added to allow you to visualise the designator, as well as the next designator calculated from the Pad Index Increment,

![image](https://github.com/user-attachments/assets/d9a39720-b4c1-4b0d-a091-7b9780775731)
![image](https://github.com/user-attachments/assets/35e8a7d7-63d4-436a-b9c3-4731de831e2c)