### PR TITLE
QuickSilk v1.21 adds visibility to QuickSilkCopy function

### DIFF
--- a/Scripts - PCB/QuickSilk/QuickSilk.pas
+++ b/Scripts - PCB/QuickSilk/QuickSilk.pas
@@ -26,7 +26,7 @@ const
     cCtrlKey            = 3; // available for use during component and location selection
     cConfigFileName     = 'QuickSilkSettings.ini';
     cScriptTitle        = 'QuickSilk';
-    cScriptVersion      = '1.20';
+    cScriptVersion      = '1.21';
     cDEBUGLEVEL         = 0;
 
 var
@@ -1057,6 +1057,25 @@ begin
 
     TargetNameOrComment.BeginModify;
     try
+        if bDesignator then
+        begin
+            if TargetComp.NameOn <> SourceComp.NameOn then
+            begin
+                TargetComp.BeginModify;
+                TargetComp.NameOn := SourceComp.NameOn;
+                TargetComp.EndModify;
+            end;
+        end
+        else
+        begin
+            if TargetComp.NameOn <> SourceComp.NameOn then
+            begin
+                TargetComp.BeginModify;
+                TargetComp.CommentOn := SourceComp.CommentOn;
+                TargetComp.EndModify;
+            end;
+        end;
+
         TargetNameOrComment.AdvanceSnapping := True;
 
         CopyTextFormatFromTo(SourceNameOrComment, TargetNameOrComment, False);

--- a/Scripts - PCB/QuickSilk/README.md
+++ b/Scripts - PCB/QuickSilk/README.md
@@ -122,6 +122,7 @@ From the GUI, you may click on the clearance labels to select all visible design
 - Added Interactive designator and comment position and format copy
 
 # Changelog
+- 2024-09-06 - QuickSilk Ver 1.21 : updated `InteractivelyCopyPosition` function to also copy visibility setting
 - 2024-04-05 - QuickSilk Ver 1.20 : added command for interactively copying designator/comment placement and formatting from source component to destination component(s); hopefully enhanced performance of IsOverlapping check by pre-checking bounding rectangles before using geometric polygons
 - 2024-01-22 - QuickSilk Ver 1.13 : fixed needing to run GUI at least once; fixed text normalization to happen before autopositioning
 - 2023-12-07 - QuickSilk Ver 1.12 : added nearness-to-click tie-breaker for locked components that have the same bounding area


### PR DESCRIPTION
`_QuickSilkCopy` now copies designator/comment visibility setting