### PR TITLE
PCBObjectInspector v0.43 fixes RoundCoordStr() imperial conversion

### DIFF
--- a/Scripts - PCB/PCBObjectInspector/PCBObjectInspector.pas
+++ b/Scripts - PCB/PCBObjectInspector/PCBObjectInspector.pas
@@ -1,6 +1,6 @@
 const
     cScriptTitle    = 'PCBObjectInspector';
-    cScriptVersion  = '0.42';
+    cScriptVersion  = '0.43';
     cDEBUGLEVEL     = 1;
     sLineBreak2     = sLineBreak + sLineBreak;
 
@@ -145,7 +145,7 @@ var
 begin
     Units := Board.DisplayUnit xor 1;
     case Units of
-        eImperial: Result := FloatToStr(Round(CoordToMils(coords) / 0.001) * 001) + 'mil'; // round to nearest multiple of 0.001mil (TCoord is 0.0001mil but UI TRUNCATES to display 0.001mil resolution)
+        eImperial: Result := FloatToStr(Round(CoordToMils(coords) / 0.0001) * 0.0001) + 'mil'; // round to nearest multiple of 0.0001mil (TCoord is 0.0001mil but in most places UI TRUNCATES to display 0.001mil resolution)
         eMetric: Result := FloatToStr(Round(CoordToMMs(coords) / 0.00001) * 0.00001) + 'mm'; // round to nearest multiple of 0.00001mm
         else Result := 'NaN';
     end;

--- a/Scripts - PCB/PCBObjectInspector/README.md
+++ b/Scripts - PCB/PCBObjectInspector/README.md
@@ -30,6 +30,7 @@ _Step 3_: Select objects on the PcbDoc and run `_Inspect` script procedure.
 - `AreaRatioCalc` : **ONLY WORKS ON REGIONS** Calculates the coverage ratio by area between 2 regions, or between multiple smaller regions and one larger region, such as windowed paste apertures.
 
 ## Change log
+- 2024-09-18 by Ryan Rutledge : v0.43 - fixed imperial coordinate conversion bug due to typo, and increased resolution to 0.0001 mil (even though many Altium UI elements will only show to 0.001 mil)
 - 2024-08-14 by Ryan Rutledge : v0.42 - added function `AreaRatioCalc` to calculate the coverage ratio between 2 or more regions; improved RoundCoordStr() function performance and added benchmarking routine to test it; increased metric rounding precision to 5 digits of precision
 - 2024-01-12 by Ryan Rutledge : v0.41 - fixed missing RoundCoords function; added length and width to fill inspector
 - 2024-01-11 by Ryan Rutledge : v0.40 - added ability to compare inspector results between two of the same type of object; most Coord values will now also show display unit values (X and Y coordinates are converted relative to board origin); changed to using custom rounding for coordinate to string conversions


### PR DESCRIPTION
and increases to full resolution of 0.0001 mil